### PR TITLE
Support C# 14 extension members in CsSig

### DIFF
--- a/src/CsSig/Analyzer/AnalyzerRules.globalconfig
+++ b/src/CsSig/Analyzer/AnalyzerRules.globalconfig
@@ -1,0 +1,13 @@
+is_global = true
+
+# RS1035: 'Environment' is banned for use by analyzers. The only use is Environment.NewLine inside
+# the third-party StaticCS.IndentingBuilder source package, which is compiled into this assembly and
+# cannot be modified here. The .cssig writer normalises line endings through the host, so this does
+# not affect determinism of the analyzer's diagnostics.
+dotnet_diagnostic.RS1035.severity = none
+
+# RS1037: suggests adding the "CompilationEnd" custom tag to descriptors reported from the
+# compilation action. These diagnostics are intentionally whole-compilation (the public surface can
+# only be compared once every symbol is known); the tag is an optimisation hint that is orthogonal
+# to this change.
+dotnet_diagnostic.RS1037.severity = none

--- a/src/CsSig/Analyzer/ApiSurface.cs
+++ b/src/CsSig/Analyzer/ApiSurface.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -21,26 +22,23 @@ internal static class ApiSurface
     /// A readable signature format, used only for diagnostic messages. Equivalence is decided by
     /// the structural <see cref="ApiMember"/>, not by this string.
     /// </summary>
-    private static readonly SymbolDisplayFormat s_displayFormat =
-        new(
-            globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
-            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
-            propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
-            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-            memberOptions:
-                SymbolDisplayMemberOptions.IncludeParameters |
-                SymbolDisplayMemberOptions.IncludeContainingType |
-                SymbolDisplayMemberOptions.IncludeExplicitInterface |
-                SymbolDisplayMemberOptions.IncludeModifiers |
-                SymbolDisplayMemberOptions.IncludeConstantValue,
-            parameterOptions:
-                SymbolDisplayParameterOptions.IncludeExtensionThis |
-                SymbolDisplayParameterOptions.IncludeParamsRefOut |
-                SymbolDisplayParameterOptions.IncludeType |
-                SymbolDisplayParameterOptions.IncludeName |
-                SymbolDisplayParameterOptions.IncludeDefaultValue,
-            miscellaneousOptions:
-                SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
+    private static readonly SymbolDisplayFormat s_displayFormat = new(
+        globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        memberOptions: SymbolDisplayMemberOptions.IncludeParameters
+            | SymbolDisplayMemberOptions.IncludeContainingType
+            | SymbolDisplayMemberOptions.IncludeExplicitInterface
+            | SymbolDisplayMemberOptions.IncludeModifiers
+            | SymbolDisplayMemberOptions.IncludeConstantValue,
+        parameterOptions: SymbolDisplayParameterOptions.IncludeExtensionThis
+            | SymbolDisplayParameterOptions.IncludeParamsRefOut
+            | SymbolDisplayParameterOptions.IncludeType
+            | SymbolDisplayParameterOptions.IncludeName
+            | SymbolDisplayParameterOptions.IncludeDefaultValue,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes
+    );
 
     /// <summary>
     /// Builds a map from the structural signature of every externally visible member declared in
@@ -57,26 +55,23 @@ internal static class ApiSurface
                 continue;
             }
 
-            Add(map, type);
+            Add(type);
 
-            foreach (var member in GetApiMembers(type))
-            {
-                Add(map, member);
-            }
+            AddApiMembers(type, Add);
         }
 
         return map;
-    }
 
-    private static void Add(Dictionary<MemberIdentity, ApiEntry> map, ISymbol symbol)
-    {
-        var member = ApiMember.From(symbol);
-        if (map.ContainsKey(member.Identity))
+        void Add(ISymbol symbol)
         {
-            return;
-        }
+            var member = ApiMember.From(symbol);
+            if (map.ContainsKey(member.Identity))
+            {
+                return;
+            }
 
-        map.Add(member.Identity, new ApiEntry(member, GetLocation(symbol), GetDisplay(symbol)));
+            map.Add(member.Identity, new ApiEntry(member, GetLocation(symbol), GetDisplay(symbol)));
+        }
     }
 
     private static Location GetLocation(ISymbol symbol)
@@ -92,7 +87,7 @@ internal static class ApiSurface
 
     /// <summary>Yields the tracked members of <paramref name="type"/>, including implicit
     /// constructors and implicit record members, mirroring the Public API analyzer.</summary>
-    private static IEnumerable<ISymbol> GetApiMembers(INamedTypeSymbol type)
+    private static void AddApiMembers(INamedTypeSymbol type, Action<ISymbol> add)
     {
         foreach (var member in type.GetMembers())
         {
@@ -109,18 +104,24 @@ internal static class ApiSurface
 
             if (IsTrackedApi(member))
             {
-                yield return member;
+                add(member);
             }
         }
 
         // Implicitly declared (parameterless) constructor.
         IMethodSymbol? implicitConstructor = null;
-        if (type is { TypeKind: TypeKind.Class, InstanceConstructors.Length: 1 } or { TypeKind: TypeKind.Struct })
+        if (
+            type
+            is { TypeKind: TypeKind.Class, InstanceConstructors.Length: 1 }
+                or { TypeKind: TypeKind.Struct }
+        )
         {
-            implicitConstructor = type.InstanceConstructors.FirstOrDefault(static c => c.IsImplicitlyDeclared);
+            implicitConstructor = type.InstanceConstructors.FirstOrDefault(static c =>
+                c.IsImplicitlyDeclared
+            );
             if (implicitConstructor is not null && IsTrackedApi(implicitConstructor))
             {
-                yield return implicitConstructor;
+                add(implicitConstructor);
             }
         }
 
@@ -144,22 +145,28 @@ internal static class ApiSurface
                 continue;
             }
 
-            if (member is IMethodSymbol { IsImplicitlyDeclared: true } method && IsTrackedApi(method))
+            if (
+                member is IMethodSymbol { IsImplicitlyDeclared: true } method
+                && IsTrackedApi(method)
+            )
             {
                 // Skip accessors of explicit (non-implicit) properties: those properties are
                 // tracked through their own accessor callbacks already. Keep accessors that
                 // belong to implicit properties (e.g. record `EqualityContract`).
-                if (method.MethodKind is not (MethodKind.PropertyGet or MethodKind.PropertySet) ||
-                    method is { AssociatedSymbol.IsImplicitlyDeclared: true })
+                if (
+                    method.MethodKind is not (MethodKind.PropertyGet or MethodKind.PropertySet)
+                    || method is { AssociatedSymbol.IsImplicitlyDeclared: true }
+                )
                 {
-                    yield return method;
+                    add(method);
                 }
             }
         }
     }
 
-    private static IEnumerable<INamedTypeSymbol> AllNamedTypes(INamespaceSymbol root)
+    private static List<INamedTypeSymbol> AllNamedTypes(INamespaceSymbol root)
     {
+        var result = new List<INamedTypeSymbol>();
         var stack = new Stack<INamespaceOrTypeSymbol>();
         stack.Push(root);
 
@@ -174,12 +181,14 @@ internal static class ApiSurface
                         stack.Push(ns);
                         break;
                     case INamedTypeSymbol type:
-                        yield return type;
+                        result.Add(type);
                         stack.Push(type);
                         break;
                 }
             }
         }
+
+        return result;
     }
 
     /// <summary>
@@ -197,13 +206,22 @@ internal static class ApiSurface
             }
 
             // Enum constructors are not user-visible API.
-            if (methodSymbol is { MethodKind: MethodKind.Constructor, ContainingType.TypeKind: TypeKind.Enum })
+            if (
+                methodSymbol is
+                { MethodKind: MethodKind.Constructor, ContainingType.TypeKind: TypeKind.Enum }
+            )
             {
                 return false;
             }
 
             // For delegates, only the 'Invoke' method carries the signature.
-            if (methodSymbol is { ContainingType.TypeKind: TypeKind.Delegate, MethodKind: not MethodKind.DelegateInvoke })
+            if (
+                methodSymbol is
+                {
+                    ContainingType.TypeKind: TypeKind.Delegate,
+                    MethodKind: not MethodKind.DelegateInvoke
+                }
+            )
             {
                 return false;
             }
@@ -228,7 +246,10 @@ internal static class ApiSurface
                 case Accessibility.ProtectedOrInternal:
                     // Protected members are only externally visible if the containing type can
                     // actually be extended outside the assembly.
-                    if (current.ContainingType is not { } container || !CanTypeBeExtended(container))
+                    if (
+                        current.ContainingType is not { } container
+                        || !CanTypeBeExtended(container)
+                    )
                     {
                         return false;
                     }
@@ -244,13 +265,16 @@ internal static class ApiSurface
     {
         // A type can be extended publicly if it isn't sealed and has a constructor that is not
         // internal, private, or protected-and-internal.
-        return !type.IsSealed &&
-            type.GetMembers(InstanceConstructorName).Any(static m => m.DeclaredAccessibility switch
-            {
-                Accessibility.Internal or Accessibility.ProtectedAndInternal => false,
-                Accessibility.Private => false,
-                _ => true,
-            });
+        return !type.IsSealed
+            && type.GetMembers(InstanceConstructorName)
+                .Any(static m =>
+                    m.DeclaredAccessibility switch
+                    {
+                        Accessibility.Internal or Accessibility.ProtectedAndInternal => false,
+                        Accessibility.Private => false,
+                        _ => true,
+                    }
+                );
     }
 
     /// <summary>

--- a/src/CsSig/Analyzer/ApiSurface.cs
+++ b/src/CsSig/Analyzer/ApiSurface.cs
@@ -126,8 +126,19 @@ internal static class ApiSurface
 
         // Implicitly declared members of a record (Equals, GetHashCode, Deconstruct, copy ctor,
         // positional property accessors, ...).
+        //
+        // A static class hosting extension blocks also carries implicit *implementation* methods
+        // for each extension member (e.g. `get_Empty`, `TryFirst`). Those are implementation
+        // details: the members themselves are tracked through the extension marker types, so skip
+        // the implicit-method pass for such classes to avoid double-counting.
+        bool hostsExtensions = ExtensionMembers.ContainsExtension(type);
         foreach (var member in type.GetMembers())
         {
+            if (hostsExtensions)
+            {
+                break;
+            }
+
             if (SymbolEqualityComparer.Default.Equals(member, implicitConstructor))
             {
                 continue;

--- a/src/CsSig/Analyzer/CsSigAnalyzer.cs
+++ b/src/CsSig/Analyzer/CsSigAnalyzer.cs
@@ -26,7 +26,8 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
         messageFormat: "The signature '{0}' is declared in a .cssig file but is not part of the project's public API (breaks {1} equivalence)",
         category: "CsSig",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true
+    );
 
     private static readonly DiagnosticDescriptor s_missingFromSignature = new(
         id: DiagId.MissingFromSignature.ToIdString(),
@@ -34,7 +35,8 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
         messageFormat: "The signature '{0}' is part of the project's public API but is not declared in any .cssig file (breaks {1} equivalence)",
         category: "CsSig",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true
+    );
 
     private static readonly DiagnosticDescriptor s_signatureFileError = new(
         id: DiagId.SignatureFileError.ToIdString(),
@@ -42,7 +44,8 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
         messageFormat: "The .cssig file could not be parsed: {0}",
         category: "CsSig",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true
+    );
 
     private static readonly DiagnosticDescriptor s_signatureMismatch = new(
         id: DiagId.SignatureMismatch.ToIdString(),
@@ -50,11 +53,17 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
         messageFormat: "The signature '{0}' is declared in a .cssig file but does not match the project's public API (breaks {1} equivalence)",
         category: "CsSig",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true
+    );
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(
-            s_missingFromProject, s_missingFromSignature, s_signatureFileError, s_signatureMismatch, CsSigRecognizer.Rule);
+            s_missingFromProject,
+            s_missingFromSignature,
+            s_signatureFileError,
+            s_signatureMismatch,
+            CsSigRecognizer.Rule
+        );
 
     public override void Initialize(AnalysisContext context)
     {
@@ -67,8 +76,10 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
     {
         var compilation = context.Compilation;
 
-        var sigFiles = context.Options.AdditionalFiles
-            .Where(static f => f.Path.EndsWith(Extension, System.StringComparison.OrdinalIgnoreCase))
+        var sigFiles = context
+            .Options.AdditionalFiles.Where(static f =>
+                f.Path.EndsWith(Extension, System.StringComparison.OrdinalIgnoreCase)
+            )
             .ToImmutableArray();
 
         // Nothing to enforce unless the project declares signatures. When one or more .cssig
@@ -78,7 +89,8 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var parseOptions = compilation.SyntaxTrees.FirstOrDefault()?.Options as CSharpParseOptions
+        var parseOptions =
+            compilation.SyntaxTrees.FirstOrDefault()?.Options as CSharpParseOptions
             ?? CSharpParseOptions.Default;
 
         var sigTrees = new List<SyntaxTree>(sigFiles.Length);
@@ -91,17 +103,25 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var tree = CSharpSyntaxTree.ParseText(text, parseOptions, path: file.Path, cancellationToken: context.CancellationToken);
+            var tree = CSharpSyntaxTree.ParseText(
+                text,
+                parseOptions,
+                path: file.Path,
+                cancellationToken: context.CancellationToken
+            );
 
             foreach (var diagnostic in tree.GetDiagnostics(context.CancellationToken))
             {
                 if (diagnostic.Severity == DiagnosticSeverity.Error)
                 {
                     hadParseError = true;
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        s_signatureFileError,
-                        CsSigLocation.ToExternal(diagnostic.Location, file.Path),
-                        diagnostic.GetMessage()));
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(
+                            s_signatureFileError,
+                            CsSigLocation.ToExternal(diagnostic.Location, file.Path),
+                            diagnostic.GetMessage()
+                        )
+                    );
                 }
             }
 
@@ -126,7 +146,8 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
             "__cssig__",
             sigTrees,
             compilation.References,
-            compilation.Options as CSharpCompilationOptions);
+            compilation.Options as CSharpCompilationOptions
+        );
 
         var declared = ApiSurface.Collect(sigCompilation.Assembly);
         var actual = ApiSurface.Collect(compilation.Assembly);
@@ -141,30 +162,40 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
             {
                 // Declared in a .cssig file but missing from the project. An add/remove breaks
                 // whichever equivalence is being enforced.
-                context.ReportDiagnostic(Diagnostic.Create(
-                    s_missingFromProject,
-                    CsSigLocation.ToExternal(pair.Value.Location, sigFiles[0].Path),
-                    pair.Value.Display,
-                    Describe(mode)));
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        s_missingFromProject,
+                        CsSigLocation.ToExternal(pair.Value.Location, sigFiles[0].Path),
+                        pair.Value.Display,
+                        Describe(mode)
+                    )
+                );
                 continue;
             }
 
             // Present on both sides: the identities match, so compare the equivalence projections
             // that are active. A common-aspect change differs in both views, yielding a single
             // diagnostic labelled with both equivalences.
-            var sourceDiffers = (mode & Equivalence.Source) != 0
+            var sourceDiffers =
+                (mode & Equivalence.Source) != 0
                 && !Equals(pair.Value.Member.Source, actualEntry.Member.Source);
-            var binaryDiffers = (mode & Equivalence.Binary) != 0
+            var binaryDiffers =
+                (mode & Equivalence.Binary) != 0
                 && !Equals(pair.Value.Member.Binary, actualEntry.Member.Binary);
 
             if (sourceDiffers || binaryDiffers)
             {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    s_signatureMismatch,
-                    CsSigLocation.ToExternal(pair.Value.Location, sigFiles[0].Path),
-                    pair.Value.Display,
-                    Describe(
-                        (sourceDiffers ? Equivalence.Source : 0) | (binaryDiffers ? Equivalence.Binary : 0))));
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        s_signatureMismatch,
+                        CsSigLocation.ToExternal(pair.Value.Location, sigFiles[0].Path),
+                        pair.Value.Display,
+                        Describe(
+                            (sourceDiffers ? Equivalence.Source : 0)
+                                | (binaryDiffers ? Equivalence.Binary : 0)
+                        )
+                    )
+                );
             }
         }
 
@@ -174,11 +205,14 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
             context.CancellationToken.ThrowIfCancellationRequested();
             if (!declared.ContainsKey(pair.Key))
             {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    s_missingFromSignature,
-                    pair.Value.Location,
-                    pair.Value.Display,
-                    Describe(mode)));
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        s_missingFromSignature,
+                        pair.Value.Location,
+                        pair.Value.Display,
+                        Describe(mode)
+                    )
+                );
             }
         }
     }
@@ -189,9 +223,12 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
     /// </summary>
     private static Equivalence ReadEquivalence(AnalyzerOptions options)
     {
-        if (options.AnalyzerConfigOptionsProvider.GlobalOptions
-                .TryGetValue("build_property.CsSigEquivalence", out var raw)
-            && !string.IsNullOrWhiteSpace(raw))
+        if (
+            options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue(
+                "build_property.CsSigEquivalence",
+                out var raw
+            ) && !string.IsNullOrWhiteSpace(raw)
+        )
         {
             switch (raw.Trim().ToLowerInvariant())
             {
@@ -208,13 +245,14 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
         return Equivalence.Both;
     }
 
-    private static string Describe(Equivalence equivalence) => equivalence switch
-    {
-        Equivalence.Source => "source",
-        Equivalence.Binary => "binary",
-        Equivalence.Both => "source and binary",
-        _ => "no",
-    };
+    private static string Describe(Equivalence equivalence) =>
+        equivalence switch
+        {
+            Equivalence.Source => "source",
+            Equivalence.Binary => "binary",
+            Equivalence.Both => "source and binary",
+            _ => "no",
+        };
 }
 
 /// <summary>The equivalence relation(s) the analyzer enforces between project and signatures.</summary>

--- a/src/CsSig/Analyzer/CsSigRecognizer.cs
+++ b/src/CsSig/Analyzer/CsSigRecognizer.cs
@@ -39,13 +39,17 @@ internal static class CsSigRecognizer
         messageFormat: "{0}",
         category: "CsSig",
         defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true
+    );
 
     /// <summary>
     /// Recognizes <paramref name="tree"/> against the <c>.cssig</c> grammar, yielding a diagnostic
     /// for every construct that the grammar does not allow.
     /// </summary>
-    public static IEnumerable<Diagnostic> Recognize(SyntaxTree tree, CancellationToken cancellationToken = default)
+    public static IEnumerable<Diagnostic> Recognize(
+        SyntaxTree tree,
+        CancellationToken cancellationToken = default
+    )
     {
         var walker = new Walker(tree.FilePath);
         walker.Visit(tree.GetRoot(cancellationToken));
@@ -60,12 +64,17 @@ internal static class CsSigRecognizer
 
         public List<Diagnostic> Diagnostics { get; } = new();
 
-        private void Report(Location location, string message)
-            => Diagnostics.Add(Diagnostic.Create(Rule, CsSigLocation.ToExternal(location, _path), message));
+        private void Report(Location location, string message) =>
+            Diagnostics.Add(
+                Diagnostic.Create(Rule, CsSigLocation.ToExternal(location, _path), message)
+            );
 
-        private static bool IsAccessibility(SyntaxKind kind)
-            => kind is SyntaxKind.PublicKeyword or SyntaxKind.PrivateKeyword
-                or SyntaxKind.ProtectedKeyword or SyntaxKind.InternalKeyword;
+        private static bool IsAccessibility(SyntaxKind kind) =>
+            kind
+                is SyntaxKind.PublicKeyword
+                    or SyntaxKind.PrivateKeyword
+                    or SyntaxKind.ProtectedKeyword
+                    or SyntaxKind.InternalKeyword;
 
         /// <summary>
         /// Modifiers allowed on a virtualizable member (method, property, indexer, event): the
@@ -109,7 +118,8 @@ internal static class CsSigRecognizer
 
                 Report(
                     modifier.GetLocation(),
-                    $"The '{modifier.ValueText}' modifier does not affect the signature and is not allowed in a .cssig file");
+                    $"The '{modifier.ValueText}' modifier does not affect the signature and is not allowed in a .cssig file"
+                );
             }
         }
 
@@ -119,14 +129,16 @@ internal static class CsSigRecognizer
             {
                 Report(
                     body.GetLocation(),
-                    "Member bodies are not allowed in a .cssig file; signatures declare members without an implementation");
+                    "Member bodies are not allowed in a .cssig file; signatures declare members without an implementation"
+                );
             }
 
             if (expressionBody is not null)
             {
                 Report(
                     expressionBody.GetLocation(),
-                    "Expression bodies are not allowed in a .cssig file; signatures declare members without an implementation");
+                    "Expression bodies are not allowed in a .cssig file; signatures declare members without an implementation"
+                );
             }
         }
 
@@ -134,7 +146,12 @@ internal static class CsSigRecognizer
         {
             // 'static'/'abstract'/'sealed' all affect the type's signature (instantiation,
             // extensibility of protected members, virtual dispatch).
-            CheckModifiers(node.Modifiers, SyntaxKind.StaticKeyword, SyntaxKind.AbstractKeyword, SyntaxKind.SealedKeyword);
+            CheckModifiers(
+                node.Modifiers,
+                SyntaxKind.StaticKeyword,
+                SyntaxKind.AbstractKeyword,
+                SyntaxKind.SealedKeyword
+            );
             base.VisitClassDeclaration(node);
         }
 
@@ -159,7 +176,12 @@ internal static class CsSigRecognizer
             }
             else
             {
-                CheckModifiers(node.Modifiers, SyntaxKind.StaticKeyword, SyntaxKind.AbstractKeyword, SyntaxKind.SealedKeyword);
+                CheckModifiers(
+                    node.Modifiers,
+                    SyntaxKind.StaticKeyword,
+                    SyntaxKind.AbstractKeyword,
+                    SyntaxKind.SealedKeyword
+                );
             }
 
             base.VisitRecordDeclaration(node);
@@ -193,7 +215,9 @@ internal static class CsSigRecognizer
             base.VisitOperatorDeclaration(node);
         }
 
-        public override void VisitConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node)
+        public override void VisitConversionOperatorDeclaration(
+            ConversionOperatorDeclarationSyntax node
+        )
         {
             CheckModifiers(node.Modifiers, SyntaxKind.StaticKeyword);
             RejectBody(node.Body, node.ExpressionBody);
@@ -244,7 +268,12 @@ internal static class CsSigRecognizer
         {
             // 'static' -> ApiMember.IsStatic; 'const' -> the captured constant value;
             // 'readonly' -> the field's read-only-ness (observable to external writers).
-            CheckModifiers(node.Modifiers, SyntaxKind.StaticKeyword, SyntaxKind.ConstKeyword, SyntaxKind.ReadOnlyKeyword);
+            CheckModifiers(
+                node.Modifiers,
+                SyntaxKind.StaticKeyword,
+                SyntaxKind.ConstKeyword,
+                SyntaxKind.ReadOnlyKeyword
+            );
 
             // A field's value is only part of the signature when it is 'const'; any other
             // initializer is invisible to the comparison.
@@ -256,7 +285,8 @@ internal static class CsSigRecognizer
                     {
                         Report(
                             initializer.GetLocation(),
-                            "A field initializer does not affect the signature and is not allowed in a .cssig file; only 'const' values are part of the signature");
+                            "A field initializer does not affect the signature and is not allowed in a .cssig file; only 'const' values are part of the signature"
+                        );
                     }
                 }
             }

--- a/src/CsSig/Analyzer/CsSigWriter.cs
+++ b/src/CsSig/Analyzer/CsSigWriter.cs
@@ -157,7 +157,16 @@ public static class CsSigWriter
                 builder.AppendLine(FormatMember(member));
             }
 
-            foreach (var nested in Sorted(type.GetMembers().OfType<INamedTypeSymbol>().Where(ApiSurface.IsTrackedApi)))
+            var nestedTypes = type.GetMembers().OfType<INamedTypeSymbol>().Where(ApiSurface.IsTrackedApi).ToList();
+
+            // Extension blocks are nested types with an unspeakable name; emit them as
+            // `extension(Receiver) { ... }` ordered by their header so the output is deterministic.
+            foreach (var extension in nestedTypes.Where(ExtensionMembers.IsExtension).OrderBy(ExtensionHeader, StringComparer.Ordinal))
+            {
+                WriteExtension(builder, extension);
+            }
+
+            foreach (var nested in Sorted(nestedTypes.Where(static t => !ExtensionMembers.IsExtension(t))))
             {
                 WriteType(builder, nested);
             }
@@ -165,6 +174,45 @@ public static class CsSigWriter
 
         builder.Dedent();
         builder.AppendLine("}");
+    }
+
+    private static void WriteExtension(IndentingBuilder builder, INamedTypeSymbol extension)
+    {
+        builder.AppendLine(ExtensionHeader(extension));
+        builder.AppendLine("{");
+        builder.Indent();
+
+        foreach (var member in Sorted(VisibleMembers(extension)))
+        {
+            builder.AppendLine(FormatMember(member));
+        }
+
+        builder.Dedent();
+        builder.AppendLine("}");
+    }
+
+    /// <summary>The header of an extension block, e.g. <c>extension(int)</c> or
+    /// <c>extension&lt;T&gt;(T[] source)</c>. The receiver is the block's marker type's receiver
+    /// parameter; its name is emitted only when the source declared one.</summary>
+    private static string ExtensionHeader(INamedTypeSymbol extension)
+    {
+        var receiver = ExtensionMembers.Receiver(extension);
+        var receiverText = receiver is null ? string.Empty : FormatReceiver(receiver);
+        return $"extension{TypeParameterList(extension)}({receiverText})";
+    }
+
+    private static string FormatReceiver(IParameterSymbol receiver)
+    {
+        var prefix = receiver.RefKind switch
+        {
+            RefKind.Ref => "ref ",
+            RefKind.Out => "out ",
+            RefKind.In => "in ",
+            _ => string.Empty,
+        };
+
+        var type = prefix + receiver.Type.ToDisplayString(s_typeFormat);
+        return receiver.Name.Length == 0 ? type : type + " " + receiver.Name;
     }
 
     /// <summary>Generates the body-less declaration text of a single member, exactly as it should

--- a/src/CsSig/Analyzer/CsSigWriter.cs
+++ b/src/CsSig/Analyzer/CsSigWriter.cs
@@ -27,36 +27,34 @@ public static class CsSigWriter
         globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
         typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
         genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-        memberOptions:
-            SymbolDisplayMemberOptions.IncludeParameters |
-            SymbolDisplayMemberOptions.IncludeType |
-            SymbolDisplayMemberOptions.IncludeModifiers |
-            SymbolDisplayMemberOptions.IncludeAccessibility |
-            SymbolDisplayMemberOptions.IncludeConstantValue |
-            SymbolDisplayMemberOptions.IncludeRef |
-            SymbolDisplayMemberOptions.IncludeExplicitInterface,
+        memberOptions: SymbolDisplayMemberOptions.IncludeParameters
+            | SymbolDisplayMemberOptions.IncludeType
+            | SymbolDisplayMemberOptions.IncludeModifiers
+            | SymbolDisplayMemberOptions.IncludeAccessibility
+            | SymbolDisplayMemberOptions.IncludeConstantValue
+            | SymbolDisplayMemberOptions.IncludeRef
+            | SymbolDisplayMemberOptions.IncludeExplicitInterface,
         kindOptions: SymbolDisplayKindOptions.IncludeMemberKeyword,
         propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
-        parameterOptions:
-            SymbolDisplayParameterOptions.IncludeType |
-            SymbolDisplayParameterOptions.IncludeName |
-            SymbolDisplayParameterOptions.IncludeParamsRefOut |
-            SymbolDisplayParameterOptions.IncludeExtensionThis |
-            SymbolDisplayParameterOptions.IncludeDefaultValue,
-        miscellaneousOptions:
-            SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
-            SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
-            SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
+        parameterOptions: SymbolDisplayParameterOptions.IncludeType
+            | SymbolDisplayParameterOptions.IncludeName
+            | SymbolDisplayParameterOptions.IncludeParamsRefOut
+            | SymbolDisplayParameterOptions.IncludeExtensionThis
+            | SymbolDisplayParameterOptions.IncludeDefaultValue,
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes
+            | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+            | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
+    );
 
     // A bare type reference, fully qualified, for return/parameter/underlying types.
     private static readonly SymbolDisplayFormat s_typeFormat = new(
         globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
         typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
         genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
-        miscellaneousOptions:
-            SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
-            SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier |
-            SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
+        miscellaneousOptions: SymbolDisplayMiscellaneousOptions.UseSpecialTypes
+            | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+            | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
+    );
 
     /// <summary>Generates the <c>.cssig</c> text for <paramref name="compilation"/>'s public API.</summary>
     public static string Write(Compilation compilation) => Write(compilation.Assembly);
@@ -73,7 +71,9 @@ public static class CsSigWriter
     /// </summary>
     public static string Write(IAssemblySymbol assembly, ISet<string>? topLevelKeys)
     {
-        var byNamespace = new SortedDictionary<string, List<INamedTypeSymbol>>(StringComparer.Ordinal);
+        var byNamespace = new SortedDictionary<string, List<INamedTypeSymbol>>(
+            StringComparer.Ordinal
+        );
         foreach (var type in TopLevelTypes(assembly.GlobalNamespace))
         {
             if (!ApiSurface.IsTrackedApi(type))
@@ -86,7 +86,9 @@ public static class CsSigWriter
                 continue;
             }
 
-            var ns = type.ContainingNamespace is { IsGlobalNamespace: false } n ? n.ToDisplayString() : string.Empty;
+            var ns = type.ContainingNamespace is { IsGlobalNamespace: false } n
+                ? n.ToDisplayString()
+                : string.Empty;
             if (!byNamespace.TryGetValue(ns, out var list))
             {
                 byNamespace[ns] = list = new List<INamedTypeSymbol>();
@@ -145,7 +147,9 @@ public static class CsSigWriter
 
         if (type.TypeKind == TypeKind.Enum)
         {
-            foreach (var field in type.GetMembers().OfType<IFieldSymbol>().Where(f => f.HasConstantValue))
+            foreach (
+                var field in type.GetMembers().OfType<IFieldSymbol>().Where(f => f.HasConstantValue)
+            )
             {
                 builder.AppendLine(FormatMember(field));
             }
@@ -157,16 +161,27 @@ public static class CsSigWriter
                 builder.AppendLine(FormatMember(member));
             }
 
-            var nestedTypes = type.GetMembers().OfType<INamedTypeSymbol>().Where(ApiSurface.IsTrackedApi).ToList();
+            var nestedTypes = type.GetMembers()
+                .OfType<INamedTypeSymbol>()
+                .Where(ApiSurface.IsTrackedApi)
+                .ToList();
 
             // Extension blocks are nested types with an unspeakable name; emit them as
             // `extension(Receiver) { ... }` ordered by their header so the output is deterministic.
-            foreach (var extension in nestedTypes.Where(ExtensionMembers.IsExtension).OrderBy(ExtensionHeader, StringComparer.Ordinal))
+            foreach (
+                var extension in nestedTypes
+                    .Where(ExtensionMembers.IsExtension)
+                    .OrderBy(ExtensionHeader, StringComparer.Ordinal)
+            )
             {
                 WriteExtension(builder, extension);
             }
 
-            foreach (var nested in Sorted(nestedTypes.Where(static t => !ExtensionMembers.IsExtension(t))))
+            foreach (
+                var nested in Sorted(
+                    nestedTypes.Where(static t => !ExtensionMembers.IsExtension(t))
+                )
+            )
             {
                 WriteType(builder, nested);
             }
@@ -225,7 +240,8 @@ public static class CsSigWriter
             return $"{enumField.Name} = {FormatConstant(enumField.ConstantValue)},";
         }
 
-        var text = member.ToDisplayString(s_memberFormat)
+        var text = member
+            .ToDisplayString(s_memberFormat)
             .Replace("volatile ", string.Empty)
             .Replace("required ", string.Empty);
 
@@ -255,14 +271,16 @@ public static class CsSigWriter
             }
         }
 
-        parts.Add(type.TypeKind switch
-        {
-            TypeKind.Class => type.IsRecord ? "record" : "class",
-            TypeKind.Struct => type.IsRecord ? "record struct" : "struct",
-            TypeKind.Interface => "interface",
-            TypeKind.Enum => "enum",
-            _ => "class",
-        });
+        parts.Add(
+            type.TypeKind switch
+            {
+                TypeKind.Class => type.IsRecord ? "record" : "class",
+                TypeKind.Struct => type.IsRecord ? "record struct" : "struct",
+                TypeKind.Interface => "interface",
+                TypeKind.Enum => "enum",
+                _ => "class",
+            }
+        );
 
         parts.Add(type.Name + TypeParameterList(type));
         return string.Join(" ", parts);
@@ -271,29 +289,36 @@ public static class CsSigWriter
     private static string DelegateDeclaration(INamedTypeSymbol type)
     {
         var invoke = type.DelegateInvokeMethod!;
-        var @return = (invoke.ReturnsByRef ? "ref " : invoke.ReturnsByRefReadonly ? "ref readonly " : string.Empty)
-            + invoke.ReturnType.ToDisplayString(s_typeFormat);
+        var @return =
+            (
+                invoke.ReturnsByRef ? "ref "
+                : invoke.ReturnsByRefReadonly ? "ref readonly "
+                : string.Empty
+            ) + invoke.ReturnType.ToDisplayString(s_typeFormat);
         return $"{Accessibility(type.DeclaredAccessibility)} delegate {@return} "
             + $"{type.Name}{TypeParameterList(type)}({FormatParameters(invoke.Parameters)})";
     }
 
-    private static string TypeParameterList(INamedTypeSymbol type)
-        => type.TypeParameters.IsEmpty
+    private static string TypeParameterList(INamedTypeSymbol type) =>
+        type.TypeParameters.IsEmpty
             ? string.Empty
             : "<" + string.Join(", ", type.TypeParameters.Select(p => p.Name)) + ">";
 
-    private static string FormatParameters(IEnumerable<IParameterSymbol> parameters)
-        => string.Join(", ", parameters.Select(p =>
-        {
-            var prefix = p.RefKind switch
+    private static string FormatParameters(IEnumerable<IParameterSymbol> parameters) =>
+        string.Join(
+            ", ",
+            parameters.Select(p =>
             {
-                RefKind.Ref => "ref ",
-                RefKind.Out => "out ",
-                RefKind.In => "in ",
-                _ => string.Empty,
-            };
-            return prefix + p.Type.ToDisplayString(s_typeFormat) + " " + p.Name;
-        }));
+                var prefix = p.RefKind switch
+                {
+                    RefKind.Ref => "ref ",
+                    RefKind.Out => "out ",
+                    RefKind.In => "in ",
+                    _ => string.Empty,
+                };
+                return prefix + p.Type.ToDisplayString(s_typeFormat) + " " + p.Name;
+            })
+        );
 
     /// <summary>The members of <paramref name="type"/> that should appear in the signature file:
     /// explicitly declared, externally visible non-type members, excluding accessors (emitted via
@@ -307,11 +332,15 @@ public static class CsSigWriter
                 continue;
             }
 
-            if (member is IMethodSymbol
+            if (
+                member is IMethodSymbol
                 {
-                    MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet
-                        or MethodKind.EventAdd or MethodKind.EventRemove,
-                })
+                    MethodKind: MethodKind.PropertyGet
+                        or MethodKind.PropertySet
+                        or MethodKind.EventAdd
+                        or MethodKind.EventRemove,
+                }
+            )
             {
                 continue;
             }
@@ -323,14 +352,15 @@ public static class CsSigWriter
         }
     }
 
-    private static bool IsVisible(ISymbol member) => member switch
-    {
-        // Properties are tracked through their accessors; emit the property if either surfaces.
-        IPropertySymbol property =>
-            (property.GetMethod is { } getter && ApiSurface.IsTrackedApi(getter))
-            || (property.SetMethod is { } setter && ApiSurface.IsTrackedApi(setter)),
-        _ => ApiSurface.IsTrackedApi(member),
-    };
+    private static bool IsVisible(ISymbol member) =>
+        member switch
+        {
+            // Properties are tracked through their accessors; emit the property if either surfaces.
+            IPropertySymbol property => (
+                property.GetMethod is { } getter && ApiSurface.IsTrackedApi(getter)
+            ) || (property.SetMethod is { } setter && ApiSurface.IsTrackedApi(setter)),
+            _ => ApiSurface.IsTrackedApi(member),
+        };
 
     private static IEnumerable<INamedTypeSymbol> TopLevelTypes(INamespaceSymbol root)
     {
@@ -353,8 +383,9 @@ public static class CsSigWriter
         }
     }
 
-    private static IEnumerable<T> Sorted<T>(IEnumerable<T> symbols) where T : ISymbol
-        => symbols.OrderBy(s => s.ToDisplayString(s_memberFormat), StringComparer.Ordinal);
+    private static IEnumerable<T> Sorted<T>(IEnumerable<T> symbols)
+        where T : ISymbol =>
+        symbols.OrderBy(s => s.ToDisplayString(s_memberFormat), StringComparer.Ordinal);
 
     /// <summary>
     /// A stable identity for a <em>top-level</em> type — its namespace-qualified name plus generic
@@ -364,22 +395,25 @@ public static class CsSigWriter
     /// </summary>
     public static string TopLevelKey(INamedTypeSymbol type)
     {
-        var ns = type.ContainingNamespace is { IsGlobalNamespace: false } n ? n.ToDisplayString() + "." : string.Empty;
+        var ns = type.ContainingNamespace is { IsGlobalNamespace: false } n
+            ? n.ToDisplayString() + "."
+            : string.Empty;
         var name = type.Arity > 0 ? type.Name + "`" + type.Arity : type.Name;
         return ns + name;
     }
 
-    private static string Accessibility(Accessibility accessibility) => accessibility switch
-    {
-        Microsoft.CodeAnalysis.Accessibility.Public => "public",
-        Microsoft.CodeAnalysis.Accessibility.Protected => "protected",
-        Microsoft.CodeAnalysis.Accessibility.ProtectedOrInternal => "protected internal",
-        Microsoft.CodeAnalysis.Accessibility.ProtectedAndInternal => "private protected",
-        Microsoft.CodeAnalysis.Accessibility.Internal => "internal",
-        Microsoft.CodeAnalysis.Accessibility.Private => "private",
-        _ => "internal",
-    };
+    private static string Accessibility(Accessibility accessibility) =>
+        accessibility switch
+        {
+            Microsoft.CodeAnalysis.Accessibility.Public => "public",
+            Microsoft.CodeAnalysis.Accessibility.Protected => "protected",
+            Microsoft.CodeAnalysis.Accessibility.ProtectedOrInternal => "protected internal",
+            Microsoft.CodeAnalysis.Accessibility.ProtectedAndInternal => "private protected",
+            Microsoft.CodeAnalysis.Accessibility.Internal => "internal",
+            Microsoft.CodeAnalysis.Accessibility.Private => "private",
+            _ => "internal",
+        };
 
-    private static string FormatConstant(object? value)
-        => value is null ? "null" : Convert.ToString(value, CultureInfo.InvariantCulture) ?? "null";
+    private static string FormatConstant(object? value) =>
+        value is null ? "null" : Convert.ToString(value, CultureInfo.InvariantCulture) ?? "null";
 }

--- a/src/CsSig/Analyzer/ExtensionMembers.cs
+++ b/src/CsSig/Analyzer/ExtensionMembers.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Microsoft.CodeAnalysis;
 
 namespace CsSig;
@@ -6,9 +5,9 @@ namespace CsSig;
 /// <summary>
 /// Helpers for C# "extension" members (<c>extension(Receiver) { ... }</c>). Roslyn models an
 /// extension block as a nested type whose <see cref="ITypeSymbol.TypeKind"/> is
-/// <c>TypeKind.Extension</c> and whose name is an unspeakable, compiler-generated marker derived
-/// from the block's contents. The members declared inside the block live on that marker type; the
-/// enclosing static class carries only their (implicit) implementations.
+/// <see cref="TypeKind.Extension"/> and whose name is an unspeakable, compiler-generated marker
+/// derived from the block's contents. The members declared inside the block live on that marker
+/// type; the enclosing static class carries only their (implicit) implementations.
 /// </summary>
 internal static class ExtensionMembers
 {
@@ -19,19 +18,8 @@ internal static class ExtensionMembers
     /// </summary>
     public const string Name = "<extension>";
 
-    // TypeKind.Extension is newer than the Roslyn baseline this analyzer compiles against, but the
-    // host compiler reports it at runtime. Reference it by its numeric value (mirroring how
-    // ApiMember handles RefKind.RefReadOnlyParameter) so the analyzer keeps targeting the older
-    // Roslyn version.
-    private const TypeKind ExtensionKind = (TypeKind)14;
-
-    // INamedTypeSymbol.ExtensionParameter (the receiver of an extension block) is likewise newer
-    // than the baseline, so it is read reflectively.
-    private static readonly PropertyInfo? s_extensionParameter =
-        typeof(INamedTypeSymbol).GetProperty("ExtensionParameter");
-
     /// <summary>Whether <paramref name="type"/> is an extension marker type.</summary>
-    public static bool IsExtension(INamedTypeSymbol type) => type.TypeKind == ExtensionKind;
+    public static bool IsExtension(INamedTypeSymbol type) => type.IsExtension;
 
     /// <summary>
     /// Whether <paramref name="type"/> directly contains any extension block (i.e. it is a static
@@ -42,7 +30,7 @@ internal static class ExtensionMembers
     {
         foreach (var member in type.GetTypeMembers())
         {
-            if (IsExtension(member))
+            if (member.IsExtension)
             {
                 return true;
             }
@@ -55,6 +43,5 @@ internal static class ExtensionMembers
     /// The receiver parameter of an extension block (e.g. the <c>int</c> in <c>extension(int)</c>),
     /// or <see langword="null"/> when it cannot be determined.
     /// </summary>
-    public static IParameterSymbol? Receiver(INamedTypeSymbol type) =>
-        s_extensionParameter?.GetValue(type) as IParameterSymbol;
+    public static IParameterSymbol? Receiver(INamedTypeSymbol type) => type.ExtensionParameter;
 }

--- a/src/CsSig/Analyzer/ExtensionMembers.cs
+++ b/src/CsSig/Analyzer/ExtensionMembers.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace CsSig;
+
+/// <summary>
+/// Helpers for C# "extension" members (<c>extension(Receiver) { ... }</c>). Roslyn models an
+/// extension block as a nested type whose <see cref="ITypeSymbol.TypeKind"/> is
+/// <c>TypeKind.Extension</c> and whose name is an unspeakable, compiler-generated marker derived
+/// from the block's contents. The members declared inside the block live on that marker type; the
+/// enclosing static class carries only their (implicit) implementations.
+/// </summary>
+internal static class ExtensionMembers
+{
+    /// <summary>
+    /// The structural name used for an extension marker type in a <see cref="TypeRef"/> /
+    /// <see cref="MemberIdentity"/>. The real metadata name is an unspeakable content hash, so the
+    /// block is instead identified by this fixed discriminator plus its receiver type.
+    /// </summary>
+    public const string Name = "<extension>";
+
+    // TypeKind.Extension is newer than the Roslyn baseline this analyzer compiles against, but the
+    // host compiler reports it at runtime. Reference it by its numeric value (mirroring how
+    // ApiMember handles RefKind.RefReadOnlyParameter) so the analyzer keeps targeting the older
+    // Roslyn version.
+    private const TypeKind ExtensionKind = (TypeKind)14;
+
+    // INamedTypeSymbol.ExtensionParameter (the receiver of an extension block) is likewise newer
+    // than the baseline, so it is read reflectively.
+    private static readonly PropertyInfo? s_extensionParameter =
+        typeof(INamedTypeSymbol).GetProperty("ExtensionParameter");
+
+    /// <summary>Whether <paramref name="type"/> is an extension marker type.</summary>
+    public static bool IsExtension(INamedTypeSymbol type) => type.TypeKind == ExtensionKind;
+
+    /// <summary>
+    /// Whether <paramref name="type"/> directly contains any extension block (i.e. it is a static
+    /// class hosting <c>extension(...) { ... }</c> members). Such a class also carries the implicit
+    /// implementation methods of those members, which are not part of the signature surface.
+    /// </summary>
+    public static bool ContainsExtension(INamedTypeSymbol type)
+    {
+        foreach (var member in type.GetTypeMembers())
+        {
+            if (IsExtension(member))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The receiver parameter of an extension block (e.g. the <c>int</c> in <c>extension(int)</c>),
+    /// or <see langword="null"/> when it cannot be determined.
+    /// </summary>
+    public static IParameterSymbol? Receiver(INamedTypeSymbol type) =>
+        s_extensionParameter?.GetValue(type) as IParameterSymbol;
+}

--- a/src/CsSig/Analyzer/IsExternalInit.cs
+++ b/src/CsSig/Analyzer/IsExternalInit.cs
@@ -2,7 +2,5 @@ namespace System.Runtime.CompilerServices
 {
     // Required so that `record` types and `init` accessors can be used when targeting
     // netstandard2.0 (which does not ship the IsExternalInit type).
-    internal static class IsExternalInit
-    {
-    }
+    internal static class IsExternalInit { }
 }

--- a/src/CsSig/Analyzer/SignatureModel.cs
+++ b/src/CsSig/Analyzer/SignatureModel.cs
@@ -70,6 +70,20 @@ partial record TypeRef
             case INamedTypeSymbol named:
                 var container = named.ContainingType is { } containingType ? From(containingType) : null;
                 var @namespace = container is null ? NamespaceName(named.ContainingNamespace) : string.Empty;
+
+                if (ExtensionMembers.IsExtension(named))
+                {
+                    // An extension block's metadata name is an unspeakable content hash that depends
+                    // on its members, so two compilations agree only when every member agrees.
+                    // Identify it structurally by its receiver type instead, so members are paired
+                    // by the receiver they extend, independent of their sibling members.
+                    var receiver = ExtensionMembers.Receiver(named);
+                    var receiverArgs = receiver is null
+                        ? default
+                        : EqArray<TypeRef>.From(new[] { From(receiver.Type) });
+                    return new Named(@namespace, container, ExtensionMembers.Name, receiverArgs);
+                }
+
                 return new Named(
                     @namespace,
                     container,
@@ -320,8 +334,13 @@ internal sealed record ApiMember(MemberIdentity Identity, SourceMember Source, B
         {
             case INamedTypeSymbol named:
             {
+                // Extension blocks share an unspeakable empty name; key them by their receiver so
+                // two blocks that extend different receivers are distinct and members never collide.
+                var isExtension = ExtensionMembers.IsExtension(named);
+                var name = isExtension ? ExtensionMembers.Name : named.Name;
+                var typeParameters = isExtension ? ExtensionReceiverKey(named) : default;
                 var identity = new MemberIdentity(
-                    ApiMemberKind.Type, @namespace, containingType, named.Name, named.Arity, default);
+                    ApiMemberKind.Type, @namespace, containingType, name, named.Arity, typeParameters);
                 var common = new CommonTypeAspects(flags);
                 return new ApiMember(identity, new SourceMember.Type(common), new BinaryMember.Type(common));
             }
@@ -401,6 +420,19 @@ internal sealed record ApiMember(MemberIdentity Identity, SourceMember Source, B
     // carried by ParamModifiers.RefReadOnly so it surfaces as a source-only modification.
     private static RefKind BinaryRefKind(RefKind refKind)
         => refKind == RefReadOnlyParameter ? RefKind.In : refKind;
+
+    /// <summary>
+    /// The identity contribution of an extension block: its receiver parameter, encoded as a single
+    /// <see cref="ParamKey"/>, so that <see cref="MemberIdentity"/> distinguishes blocks by the
+    /// receiver they extend (the receiver may reference the block's own type parameters).
+    /// </summary>
+    private static EqArray<ParamKey> ExtensionReceiverKey(INamedTypeSymbol extension)
+    {
+        var receiver = ExtensionMembers.Receiver(extension);
+        return receiver is null
+            ? default
+            : EqArray<ParamKey>.From(new[] { new ParamKey(TypeRef.From(receiver.Type), BinaryRefKind(receiver.RefKind)) });
+    }
 
     private static string FormatConstant(object? value)
         => value is null ? "null" : Convert.ToString(value, CultureInfo.InvariantCulture) ?? "null";

--- a/src/CsSig/Analyzer/SignatureModel.cs
+++ b/src/CsSig/Analyzer/SignatureModel.cs
@@ -407,19 +407,14 @@ internal sealed record ApiMember(MemberIdentity Identity, SourceMember Source, B
         => (parameter.IsParams ? ParamModifiers.Params : ParamModifiers.None)
             | (parameter.IsThis ? ParamModifiers.This : ParamModifiers.None)
             | (parameter.HasExplicitDefaultValue ? ParamModifiers.Optional : ParamModifiers.None)
-            | (parameter.RefKind == RefReadOnlyParameter ? ParamModifiers.RefReadOnly : ParamModifiers.None);
-
-    // RefKind.RefReadOnlyParameter (C# 12) is not defined in the Roslyn baseline this analyzer
-    // compiles against, but the host compiler reports it at runtime. Reference it by its numeric
-    // value so the analyzer keeps targeting the older Roslyn version.
-    private const RefKind RefReadOnlyParameter = (RefKind)4;
+            | (parameter.RefKind == RefKind.RefReadOnlyParameter ? ParamModifiers.RefReadOnly : ParamModifiers.None);
 
     // `in` and `ref readonly` parameters share the same binary calling convention (both an
     // `in`-flagged byref with a `modreq(InAttribute)`); `ref readonly` only adds a source-level
     // `RequiresLocationAttribute`. Identity therefore pairs them, and the source difference is
     // carried by ParamModifiers.RefReadOnly so it surfaces as a source-only modification.
     private static RefKind BinaryRefKind(RefKind refKind)
-        => refKind == RefReadOnlyParameter ? RefKind.In : refKind;
+        => refKind == RefKind.RefReadOnlyParameter ? RefKind.In : refKind;
 
     /// <summary>
     /// The identity contribution of an extension block: its receiver parameter, encoded as a single

--- a/src/CsSig/Analyzer/SignatureModel.cs
+++ b/src/CsSig/Analyzer/SignatureModel.cs
@@ -20,15 +20,22 @@ internal abstract partial record TypeRef
         string Namespace,
         TypeRef? ContainingType,
         string Name,
-        EqArray<TypeRef> TypeArguments) : TypeRef;
+        EqArray<TypeRef> TypeArguments
+    ) : TypeRef;
+
     public sealed record Array(TypeRef ElementType, int Rank) : TypeRef;
+
     public sealed record Pointer(TypeRef ElementType) : TypeRef;
+
     public sealed record TypeParameter(int Ordinal, bool IsMethodTypeParameter) : TypeRef;
+
     public sealed record FunctionPointer(
         SignatureCallingConvention CallingConvention,
         EqArray<TypeRef> CallingConventionTypes,
         ParamKey Return,
-        EqArray<ParamKey> Parameters) : TypeRef;
+        EqArray<ParamKey> Parameters
+    ) : TypeRef;
+
     public sealed record Dynamic : TypeRef
     {
         public static readonly Dynamic Instance = new();
@@ -50,7 +57,8 @@ partial record TypeRef
             case ITypeParameterSymbol typeParameter:
                 return new TypeParameter(
                     typeParameter.Ordinal,
-                    typeParameter.TypeParameterKind == TypeParameterKind.Method);
+                    typeParameter.TypeParameterKind == TypeParameterKind.Method
+                );
 
             case IDynamicTypeSymbol:
                 return Dynamic.Instance;
@@ -59,17 +67,27 @@ partial record TypeRef
             {
                 var signature = functionPointer.Signature;
                 var callingConventionTypes = EqArray<TypeRef>.From(
-                    signature.UnmanagedCallingConventionTypes.Select(From));
+                    signature.UnmanagedCallingConventionTypes.Select(From)
+                );
                 var @return = new ParamKey(From(signature.ReturnType), signature.RefKind);
                 var parameters = EqArray<ParamKey>.From(
-                    signature.Parameters.Select(p => new ParamKey(From(p.Type), p.RefKind)));
+                    signature.Parameters.Select(p => new ParamKey(From(p.Type), p.RefKind))
+                );
                 return new FunctionPointer(
-                    signature.CallingConvention, callingConventionTypes, @return, parameters);
+                    signature.CallingConvention,
+                    callingConventionTypes,
+                    @return,
+                    parameters
+                );
             }
 
             case INamedTypeSymbol named:
-                var container = named.ContainingType is { } containingType ? From(containingType) : null;
-                var @namespace = container is null ? NamespaceName(named.ContainingNamespace) : string.Empty;
+                var container = named.ContainingType is { } containingType
+                    ? From(containingType)
+                    : null;
+                var @namespace = container is null
+                    ? NamespaceName(named.ContainingNamespace)
+                    : string.Empty;
 
                 if (ExtensionMembers.IsExtension(named))
                 {
@@ -88,19 +106,22 @@ partial record TypeRef
                     @namespace,
                     container,
                     named.Name,
-                    EqArray<TypeRef>.From(named.TypeArguments.Select(From)));
+                    EqArray<TypeRef>.From(named.TypeArguments.Select(From))
+                );
 
             default:
                 // The ITypeSymbol hierarchy above is exhaustive (array, pointer, type parameter,
                 // dynamic, function pointer, named/error). Anything else cannot be modeled
                 // structurally, so fail loudly rather than invent a comparison.
                 throw new ArgumentException(
-                    $"Cannot build a type reference from type kind '{type.TypeKind}'.", nameof(type));
+                    $"Cannot build a type reference from type kind '{type.TypeKind}'.",
+                    nameof(type)
+                );
         }
     }
 
-    private static string NamespaceName(INamespaceSymbol? @namespace)
-        => @namespace is null || @namespace.IsGlobalNamespace
+    private static string NamespaceName(INamespaceSymbol? @namespace) =>
+        @namespace is null || @namespace.IsGlobalNamespace
             ? string.Empty
             : @namespace.ToDisplayString();
 }
@@ -242,7 +263,11 @@ internal readonly record struct ParamKey(TypeRef Type, RefKind RefKind);
 /// <c>ref readonly</c> vs <c>in</c>), and the nullable annotations of its type. None of these change
 /// the binary calling convention.
 /// </summary>
-internal readonly record struct SourceParam(string Name, ParamModifiers Modifiers, Nullability Nullability);
+internal readonly record struct SourceParam(
+    string Name,
+    ParamModifiers Modifiers,
+    Nullability Nullability
+);
 
 /// <summary>
 /// The identity of an API member: the tuple by which two members from different compilations are
@@ -254,7 +279,8 @@ internal sealed record MemberIdentity(
     TypeRef? ContainingType,
     string Name,
     int Arity,
-    EqArray<ParamKey> Parameters);
+    EqArray<ParamKey> Parameters
+);
 
 /// <summary>
 /// The aspects of a type declaration observable to <em>every</em> consumer (source or binary):
@@ -284,7 +310,10 @@ internal abstract record SourceMember
     public sealed record Type(CommonTypeAspects Common) : SourceMember;
 
     public sealed record Method(
-        CommonMethodAspects Common, Nullability ReturnNullability, EqArray<SourceParam> Parameters) : SourceMember;
+        CommonMethodAspects Common,
+        Nullability ReturnNullability,
+        EqArray<SourceParam> Parameters
+    ) : SourceMember;
 
     public sealed record Field(CommonFieldAspects Common, Nullability Nullability) : SourceMember;
 
@@ -321,9 +350,10 @@ internal sealed record ApiMember(MemberIdentity Identity, SourceMember Source, B
     public static ApiMember From(ISymbol symbol)
     {
         var containingType = symbol.ContainingType is { } type ? TypeRef.From(type) : null;
-        var @namespace = containingType is null && symbol.ContainingNamespace is { IsGlobalNamespace: false } ns
-            ? ns.ToDisplayString()
-            : string.Empty;
+        var @namespace =
+            containingType is null && symbol.ContainingNamespace is { IsGlobalNamespace: false } ns
+                ? ns.ToDisplayString()
+                : string.Empty;
 
         // Every flag bit except a field's ReadOnly/HasConstantValue is reported generically by the
         // symbol: types expose IsAbstract/IsSealed, members expose virtuality, and the rest are
@@ -340,51 +370,93 @@ internal sealed record ApiMember(MemberIdentity Identity, SourceMember Source, B
                 var name = isExtension ? ExtensionMembers.Name : named.Name;
                 var typeParameters = isExtension ? ExtensionReceiverKey(named) : default;
                 var identity = new MemberIdentity(
-                    ApiMemberKind.Type, @namespace, containingType, name, named.Arity, typeParameters);
+                    ApiMemberKind.Type,
+                    @namespace,
+                    containingType,
+                    name,
+                    named.Arity,
+                    typeParameters
+                );
                 var common = new CommonTypeAspects(flags);
-                return new ApiMember(identity, new SourceMember.Type(common), new BinaryMember.Type(common));
+                return new ApiMember(
+                    identity,
+                    new SourceMember.Type(common),
+                    new BinaryMember.Type(common)
+                );
             }
 
             case IMethodSymbol method:
             {
                 var keys = EqArray<ParamKey>.From(
-                    method.Parameters.Select(p => new ParamKey(TypeRef.From(p.Type), BinaryRefKind(p.RefKind))));
+                    method.Parameters.Select(p => new ParamKey(
+                        TypeRef.From(p.Type),
+                        BinaryRefKind(p.RefKind)
+                    ))
+                );
                 var parameters = EqArray<SourceParam>.From(
-                    method.Parameters.Select(p => new SourceParam(p.Name, ParamModifiersFrom(p), Nullability.Of(p.Type))));
+                    method.Parameters.Select(p => new SourceParam(
+                        p.Name,
+                        ParamModifiersFrom(p),
+                        Nullability.Of(p.Type)
+                    ))
+                );
                 var identity = new MemberIdentity(
-                    ApiMemberKind.Method, @namespace, containingType, method.Name, method.Arity, keys);
+                    ApiMemberKind.Method,
+                    @namespace,
+                    containingType,
+                    method.Name,
+                    method.Arity,
+                    keys
+                );
                 var common = new CommonMethodAspects(
                     TypeRef.From(method.ReturnType),
-                    flags | (method.IsReadOnly ? MemberFlags.ReadOnly : MemberFlags.None));
+                    flags | (method.IsReadOnly ? MemberFlags.ReadOnly : MemberFlags.None)
+                );
                 return new ApiMember(
                     identity,
                     new SourceMember.Method(common, Nullability.Of(method.ReturnType), parameters),
-                    new BinaryMember.Method(common));
+                    new BinaryMember.Method(common)
+                );
             }
 
             case IFieldSymbol field:
             {
                 var identity = new MemberIdentity(
-                    ApiMemberKind.Field, @namespace, containingType, field.Name, Arity: 0, default);
-                flags |= (field.IsReadOnly ? MemberFlags.ReadOnly : MemberFlags.None)
+                    ApiMemberKind.Field,
+                    @namespace,
+                    containingType,
+                    field.Name,
+                    Arity: 0,
+                    default
+                );
+                flags |=
+                    (field.IsReadOnly ? MemberFlags.ReadOnly : MemberFlags.None)
                     | (field.HasConstantValue ? MemberFlags.HasConstantValue : MemberFlags.None);
                 var common = new CommonFieldAspects(TypeRef.From(field.Type), flags);
                 var constant = field.HasConstantValue ? FormatConstant(field.ConstantValue) : null;
                 return new ApiMember(
                     identity,
                     new SourceMember.Field(common, Nullability.Of(field.Type)),
-                    new BinaryMember.Field(common, constant));
+                    new BinaryMember.Field(common, constant)
+                );
             }
 
             case IEventSymbol @event:
             {
                 var identity = new MemberIdentity(
-                    ApiMemberKind.Event, @namespace, containingType, @event.Name, Arity: 0, default);
+                    ApiMemberKind.Event,
+                    @namespace,
+                    containingType,
+                    @event.Name,
+                    Arity: 0,
+                    default
+                );
                 var common = new CommonEventAspects(TypeRef.From(@event.Type), flags);
                 return new ApiMember(
                     identity,
                     new SourceMember.Event(common, Nullability.Of(@event.Type)),
-                    new BinaryMember.Event(common));
+                    new BinaryMember.Event(common)
+                );
             }
 
             default:
@@ -392,29 +464,35 @@ internal sealed record ApiMember(MemberIdentity Identity, SourceMember Source, B
                 // IsTrackedApi/GetApiMembers). Any other kind cannot be credibly modeled or
                 // compared, so fail loudly rather than synthesize a meaningless member.
                 throw new ArgumentException(
-                    $"Cannot build an API member from symbol kind '{symbol.Kind}'.", nameof(symbol));
+                    $"Cannot build an API member from symbol kind '{symbol.Kind}'.",
+                    nameof(symbol)
+                );
         }
     }
 
-    private static MemberFlags FlagsFrom(ISymbol symbol)
-        => (symbol.IsStatic ? MemberFlags.Static : MemberFlags.None)
-            | (symbol.IsVirtual ? MemberFlags.Virtual : MemberFlags.None)
-            | (symbol.IsAbstract ? MemberFlags.Abstract : MemberFlags.None)
-            | (symbol.IsOverride ? MemberFlags.Override : MemberFlags.None)
-            | (symbol.IsSealed ? MemberFlags.Sealed : MemberFlags.None);
+    private static MemberFlags FlagsFrom(ISymbol symbol) =>
+        (symbol.IsStatic ? MemberFlags.Static : MemberFlags.None)
+        | (symbol.IsVirtual ? MemberFlags.Virtual : MemberFlags.None)
+        | (symbol.IsAbstract ? MemberFlags.Abstract : MemberFlags.None)
+        | (symbol.IsOverride ? MemberFlags.Override : MemberFlags.None)
+        | (symbol.IsSealed ? MemberFlags.Sealed : MemberFlags.None);
 
-    private static ParamModifiers ParamModifiersFrom(IParameterSymbol parameter)
-        => (parameter.IsParams ? ParamModifiers.Params : ParamModifiers.None)
-            | (parameter.IsThis ? ParamModifiers.This : ParamModifiers.None)
-            | (parameter.HasExplicitDefaultValue ? ParamModifiers.Optional : ParamModifiers.None)
-            | (parameter.RefKind == RefKind.RefReadOnlyParameter ? ParamModifiers.RefReadOnly : ParamModifiers.None);
+    private static ParamModifiers ParamModifiersFrom(IParameterSymbol parameter) =>
+        (parameter.IsParams ? ParamModifiers.Params : ParamModifiers.None)
+        | (parameter.IsThis ? ParamModifiers.This : ParamModifiers.None)
+        | (parameter.HasExplicitDefaultValue ? ParamModifiers.Optional : ParamModifiers.None)
+        | (
+            parameter.RefKind == RefKind.RefReadOnlyParameter
+                ? ParamModifiers.RefReadOnly
+                : ParamModifiers.None
+        );
 
     // `in` and `ref readonly` parameters share the same binary calling convention (both an
     // `in`-flagged byref with a `modreq(InAttribute)`); `ref readonly` only adds a source-level
     // `RequiresLocationAttribute`. Identity therefore pairs them, and the source difference is
     // carried by ParamModifiers.RefReadOnly so it surfaces as a source-only modification.
-    private static RefKind BinaryRefKind(RefKind refKind)
-        => refKind == RefKind.RefReadOnlyParameter ? RefKind.In : refKind;
+    private static RefKind BinaryRefKind(RefKind refKind) =>
+        refKind == RefKind.RefReadOnlyParameter ? RefKind.In : refKind;
 
     /// <summary>
     /// The identity contribution of an extension block: its receiver parameter, encoded as a single
@@ -426,9 +504,11 @@ internal sealed record ApiMember(MemberIdentity Identity, SourceMember Source, B
         var receiver = ExtensionMembers.Receiver(extension);
         return receiver is null
             ? default
-            : EqArray<ParamKey>.From(new[] { new ParamKey(TypeRef.From(receiver.Type), BinaryRefKind(receiver.RefKind)) });
+            : EqArray<ParamKey>.From(
+                new[] { new ParamKey(TypeRef.From(receiver.Type), BinaryRefKind(receiver.RefKind)) }
+            );
     }
 
-    private static string FormatConstant(object? value)
-        => value is null ? "null" : Convert.ToString(value, CultureInfo.InvariantCulture) ?? "null";
+    private static string FormatConstant(object? value) =>
+        value is null ? "null" : Convert.ToString(value, CultureInfo.InvariantCulture) ?? "null";
 }

--- a/src/CsSig/Analyzer/StaticCs.CsSig.Analyzers.csproj
+++ b/src/CsSig/Analyzer/StaticCs.CsSig.Analyzers.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -17,5 +16,4 @@
     <!-- Source-only package: IndentingBuilder.cs is compiled directly into StaticCs.CsSig.Analyzers.dll. -->
     <PackageReference Include="StaticCS.IndentingBuilder" Version="0.3.0" PrivateAssets="all" />
   </ItemGroup>
-
 </Project>

--- a/src/CsSig/Analyzer/StaticCs.CsSig.Analyzers.csproj
+++ b/src/CsSig/Analyzer/StaticCs.CsSig.Analyzers.csproj
@@ -12,7 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0" />
+    <GlobalAnalyzerConfigFiles Include="AnalyzerRules.globalconfig" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     <!-- Source-only package: IndentingBuilder.cs is compiled directly into StaticCs.CsSig.Analyzers.dll. -->
     <PackageReference Include="StaticCS.IndentingBuilder" Version="0.3.0" PrivateAssets="all" />
   </ItemGroup>

--- a/src/CsSig/Analyzer/SymbolVisibility.cs
+++ b/src/CsSig/Analyzer/SymbolVisibility.cs
@@ -52,8 +52,8 @@ internal static class SymbolVisibilityExtensions
                     visibility = SymbolVisibility.Internal;
                     break;
 
-                    // For anything else (Public, Protected, ProtectedOrInternal), the
-                    // symbol stays at the level we've gotten so far.
+                // For anything else (Public, Protected, ProtectedOrInternal), the
+                // symbol stays at the level we've gotten so far.
             }
 
             current = current.ContainingSymbol;

--- a/src/CsSig/Analyzer/build/StaticCS.CsSig.props
+++ b/src/CsSig/Analyzer/build/StaticCS.CsSig.props
@@ -1,12 +1,13 @@
 <Project>
-
   <!--
     Automatically treat *.cssig files in the project as AdditionalFiles so the CsSig analyzer
     can read them. Set <EnableCsSigAnalyzer>false</EnableCsSigAnalyzer> to opt out.
   -->
   <ItemGroup Condition="'$(EnableCsSigAnalyzer)' != 'false'">
-    <AdditionalFiles Include="**/*.cssig"
-                     Exclude="$(BaseIntermediateOutputPath)**/*.cssig;$(BaseOutputPath)**/*.cssig;bin/**/*.cssig;obj/**/*.cssig" />
+    <AdditionalFiles
+      Include="**/*.cssig"
+      Exclude="$(BaseIntermediateOutputPath)**/*.cssig;$(BaseOutputPath)**/*.cssig;bin/**/*.cssig;obj/**/*.cssig"
+    />
   </ItemGroup>
 
   <!--
@@ -20,5 +21,4 @@
   <ItemGroup>
     <CompilerVisibleProperty Include="CsSigEquivalence" />
   </ItemGroup>
-
 </Project>

--- a/src/CsSig/CodeFixes/CsSigCodeFixProvider.cs
+++ b/src/CsSig/CodeFixes/CsSigCodeFixProvider.cs
@@ -52,16 +52,27 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
         var document = context.Document;
         var project = document.Project;
 
-        var compilation = await project.GetCompilationAsync(context.CancellationToken).ConfigureAwait(false);
-        var model = await document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-        var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var compilation = await project
+            .GetCompilationAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+        var model = await document
+            .GetSemanticModelAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+        var root = await document
+            .GetSyntaxRootAsync(context.CancellationToken)
+            .ConfigureAwait(false);
         if (compilation is null || model is null || root is null)
         {
             return;
         }
 
         var diagnostic = context.Diagnostics[0];
-        var symbol = ResolveMember(model, root, diagnostic.Location.SourceSpan, context.CancellationToken);
+        var symbol = ResolveMember(
+            model,
+            root,
+            diagnostic.Location.SourceSpan,
+            context.CancellationToken
+        );
         if (symbol is null)
         {
             return;
@@ -74,7 +85,9 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
         }
 
         var key = CsSigWriter.TopLevelKey(topLevel);
-        var index = await SignatureIndex.BuildAsync(project, context.CancellationToken).ConfigureAwait(false);
+        var index = await SignatureIndex
+            .BuildAsync(project, context.CancellationToken)
+            .ConfigureAwait(false);
 
         if (index.OwnerOf(key) is { } owner)
         {
@@ -83,8 +96,10 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
                 CodeAction.Create(
                     $"Add missing API to '{owner.Name}'",
                     ct => RegenerateOwningFileAsync(project, owner, index, key, ct),
-                    equivalenceKey: ToPublicApiKey),
-                diagnostic);
+                    equivalenceKey: ToPublicApiKey
+                ),
+                diagnostic
+            );
             return;
         }
 
@@ -94,20 +109,29 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
             CodeAction.Create(
                 $"Add API to '{DefaultFileName}'",
                 ct => AddTypeToNamedFileAsync(project, DefaultFileName, index, key, ct),
-                equivalenceKey: ToPublicApiKey),
-            diagnostic);
+                equivalenceKey: ToPublicApiKey
+            ),
+            diagnostic
+        );
         context.RegisterCodeFix(
             CodeAction.Create(
                 $"Add API to '{perTypeName}'",
                 ct => AddTypeToNamedFileAsync(project, perTypeName, index, key, ct),
-                equivalenceKey: ToTypeFileKey),
-            diagnostic);
+                equivalenceKey: ToTypeFileKey
+            ),
+            diagnostic
+        );
     }
 
     /// <summary>Regenerates the file that already owns <paramref name="key"/> from the project's
     /// current surface.</summary>
     private static async Task<Solution> RegenerateOwningFileAsync(
-        Project project, TextDocument owner, SignatureIndex index, string key, CancellationToken ct)
+        Project project,
+        TextDocument owner,
+        SignatureIndex index,
+        string key,
+        CancellationToken ct
+    )
     {
         var assembly = (await project.GetCompilationAsync(ct).ConfigureAwait(false))?.Assembly;
         if (assembly is null)
@@ -123,7 +147,12 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
     /// <summary>Adds <paramref name="key"/>'s type to the file named <paramref name="fileName"/>,
     /// creating it if necessary, otherwise regenerating it with the type included.</summary>
     private static async Task<Solution> AddTypeToNamedFileAsync(
-        Project project, string fileName, SignatureIndex index, string key, CancellationToken ct)
+        Project project,
+        string fileName,
+        SignatureIndex index,
+        string key,
+        CancellationToken ct
+    )
     {
         var assembly = (await project.GetCompilationAsync(ct).ConfigureAwait(false))?.Assembly;
         if (assembly is null)
@@ -136,20 +165,32 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
         {
             var keys = new HashSet<string>(index.KeysOwnedBy(existing.Id)) { key };
             var updated = CsSigWriter.Write(assembly, keys);
-            return project.Solution.WithAdditionalDocumentText(existing.Id, SourceText.From(updated));
+            return project.Solution.WithAdditionalDocumentText(
+                existing.Id,
+                SourceText.From(updated)
+            );
         }
 
         var text = CsSigWriter.Write(assembly, new HashSet<string> { key });
         return project
-            .AddAdditionalDocument(fileName, SourceText.From(text), filePath: FilePathFor(project, fileName))
+            .AddAdditionalDocument(
+                fileName,
+                SourceText.From(text),
+                filePath: FilePathFor(project, fileName)
+            )
             .Project.Solution;
     }
 
     private static string FilePathFor(Project project, string fileName)
     {
         var dir = project.FilePath is { } p ? Path.GetDirectoryName(p) : null;
-        if (dir is null
-            && project.AdditionalDocuments.Select(d => d.FilePath).FirstOrDefault(d => d is not null) is { } existing)
+        if (
+            dir is null
+            && project
+                .AdditionalDocuments.Select(d => d.FilePath)
+                .FirstOrDefault(d => d is not null)
+                is { } existing
+        )
         {
             dir = Path.GetDirectoryName(existing);
         }
@@ -161,10 +202,11 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
     /// a signature file declares. Property/event accessors are normalized to their owning member.</summary>
     private static INamedTypeSymbol? TopLevelType(ISymbol symbol)
     {
-        var member = symbol is IMethodSymbol { AssociatedSymbol: { } associated }
+        var member =
+            symbol is IMethodSymbol { AssociatedSymbol: { } associated }
             && associated is IPropertySymbol or IEventSymbol
-            ? associated
-            : symbol;
+                ? associated
+                : symbol;
 
         var type = member as INamedTypeSymbol ?? member.ContainingType;
         if (type is null)
@@ -182,13 +224,25 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
 
     /// <summary>Resolves the declared symbol the CSSIG002 diagnostic refers to, walking up from the
     /// node at <paramref name="span"/> until a member or type symbol is found.</summary>
-    private static ISymbol? ResolveMember(SemanticModel model, SyntaxNode root, TextSpan span, CancellationToken ct)
+    private static ISymbol? ResolveMember(
+        SemanticModel model,
+        SyntaxNode root,
+        TextSpan span,
+        CancellationToken ct
+    )
     {
         var node = root.FindNode(span, getInnermostNodeForTie: true);
         for (var current = node; current is not null; current = current.Parent)
         {
             var declared = model.GetDeclaredSymbol(current, ct);
-            if (declared is INamedTypeSymbol or IMethodSymbol or IPropertySymbol or IEventSymbol or IFieldSymbol)
+            if (
+                declared
+                is INamedTypeSymbol
+                    or IMethodSymbol
+                    or IPropertySymbol
+                    or IEventSymbol
+                    or IFieldSymbol
+            )
             {
                 return declared;
             }
@@ -202,12 +256,15 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
         return null;
     }
 
-    private static bool IsSignatureFile(TextDocument doc)
-        => (doc.FilePath ?? doc.Name).EndsWith(Extension, System.StringComparison.OrdinalIgnoreCase);
+    private static bool IsSignatureFile(TextDocument doc) =>
+        (doc.FilePath ?? doc.Name).EndsWith(Extension, System.StringComparison.OrdinalIgnoreCase);
 
     /// <summary>The keys (see <see cref="CsSigWriter.TopLevelKey"/>) of the top-level types declared
     /// in a <c>.cssig</c> document.</summary>
-    private static async Task<HashSet<string>> TopLevelKeysAsync(TextDocument doc, CancellationToken ct)
+    private static async Task<HashSet<string>> TopLevelKeysAsync(
+        TextDocument doc,
+        CancellationToken ct
+    )
     {
         var keys = new HashSet<string>();
         var text = await doc.GetTextAsync(ct).ConfigureAwait(false);
@@ -230,7 +287,9 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
     private static string SyntaxTopLevelKey(BaseTypeDeclarationSyntax type)
     {
         var ns = NamespaceName(type);
-        var arity = type is TypeDeclarationSyntax { TypeParameterList: { } list } ? list.Parameters.Count : 0;
+        var arity = type is TypeDeclarationSyntax { TypeParameterList: { } list }
+            ? list.Parameters.Count
+            : 0;
         var name = arity > 0 ? type.Identifier.ValueText + "`" + arity : type.Identifier.ValueText;
         return ns.Length > 0 ? ns + "." + name : name;
     }
@@ -261,7 +320,8 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
         private SignatureIndex(
             Dictionary<string, TextDocument> ownerByKey,
             Dictionary<DocumentId, HashSet<string>> keysByDocument,
-            List<TextDocument> documents)
+            List<TextDocument> documents
+        )
         {
             _ownerByKey = ownerByKey;
             _keysByDocument = keysByDocument;
@@ -293,13 +353,16 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
             return new SignatureIndex(ownerByKey, keysByDocument, documents);
         }
 
-        public TextDocument? OwnerOf(string key) => _ownerByKey.TryGetValue(key, out var doc) ? doc : null;
+        public TextDocument? OwnerOf(string key) =>
+            _ownerByKey.TryGetValue(key, out var doc) ? doc : null;
 
-        public IEnumerable<string> KeysOwnedBy(DocumentId id)
-            => _keysByDocument.TryGetValue(id, out var keys) ? keys : Enumerable.Empty<string>();
+        public IEnumerable<string> KeysOwnedBy(DocumentId id) =>
+            _keysByDocument.TryGetValue(id, out var keys) ? keys : Enumerable.Empty<string>();
 
-        public TextDocument? DocumentNamed(string name)
-            => _documents.FirstOrDefault(d => string.Equals(d.Name, name, System.StringComparison.OrdinalIgnoreCase));
+        public TextDocument? DocumentNamed(string name) =>
+            _documents.FirstOrDefault(d =>
+                string.Equals(d.Name, name, System.StringComparison.OrdinalIgnoreCase)
+            );
     }
 
     private sealed class CsSigFixAllProvider : FixAllProvider
@@ -317,8 +380,16 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
             var strategy = fixAllContext.CodeActionEquivalenceKey ?? ToPublicApiKey;
             return CodeAction.Create(
                 "Add missing API to .cssig files",
-                ct => ApplyAsync(fixAllContext.Solution, fixAllContext.Project, diagnostics, strategy, ct),
-                equivalenceKey: strategy);
+                ct =>
+                    ApplyAsync(
+                        fixAllContext.Solution,
+                        fixAllContext.Project,
+                        diagnostics,
+                        strategy,
+                        ct
+                    ),
+                equivalenceKey: strategy
+            );
         }
 
         private static async Task<ImmutableArray<Diagnostic>> GatherAsync(FixAllContext context)
@@ -326,14 +397,20 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
             switch (context.Scope)
             {
                 case FixAllScope.Document when context.Document is { } document:
-                    return await context.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                    return await context
+                        .GetDocumentDiagnosticsAsync(document)
+                        .ConfigureAwait(false);
                 case FixAllScope.Project:
-                    return await context.GetAllDiagnosticsAsync(context.Project).ConfigureAwait(false);
+                    return await context
+                        .GetAllDiagnosticsAsync(context.Project)
+                        .ConfigureAwait(false);
                 case FixAllScope.Solution:
                     var all = ImmutableArray.CreateBuilder<Diagnostic>();
                     foreach (var project in context.Solution.Projects)
                     {
-                        all.AddRange(await context.GetAllDiagnosticsAsync(project).ConfigureAwait(false));
+                        all.AddRange(
+                            await context.GetAllDiagnosticsAsync(project).ConfigureAwait(false)
+                        );
                     }
 
                     return all.ToImmutable();
@@ -349,7 +426,12 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
         /// from the project surface with the full set of types it should own.
         /// </summary>
         private static async Task<Solution> ApplyAsync(
-            Solution solution, Project project, ImmutableArray<Diagnostic> diagnostics, string strategy, CancellationToken ct)
+            Solution solution,
+            Project project,
+            ImmutableArray<Diagnostic> diagnostics,
+            string strategy,
+            CancellationToken ct
+        )
         {
             var assembly = (await project.GetCompilationAsync(ct).ConfigureAwait(false))?.Assembly;
             if (assembly is null)
@@ -360,8 +442,12 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
             var index = await SignatureIndex.BuildAsync(project, ct).ConfigureAwait(false);
 
             // fileName -> the set of top-level keys that file should own after the fix.
-            var plan = new Dictionary<string, HashSet<string>>(System.StringComparer.OrdinalIgnoreCase);
-            var existingByName = new Dictionary<string, TextDocument>(System.StringComparer.OrdinalIgnoreCase);
+            var plan = new Dictionary<string, HashSet<string>>(
+                System.StringComparer.OrdinalIgnoreCase
+            );
+            var existingByName = new Dictionary<string, TextDocument>(
+                System.StringComparer.OrdinalIgnoreCase
+            );
 
             foreach (var diagnostic in diagnostics)
             {
@@ -381,9 +467,10 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
                 }
                 else
                 {
-                    fileName = strategy == ToTypeFileKey
-                        ? TypeNameFromKey(key) + Extension
-                        : DefaultFileName;
+                    fileName =
+                        strategy == ToTypeFileKey
+                            ? TypeNameFromKey(key) + Extension
+                            : DefaultFileName;
                     target = index.DocumentNamed(fileName);
                 }
 
@@ -413,17 +500,27 @@ public sealed class CsSigCodeFixProvider : CodeFixProvider
                 {
                     var id = DocumentId.CreateNewId(project.Id);
                     solution = solution.AddAdditionalDocument(
-                        id, entry.Key, text, filePath: FilePathFor(project, entry.Key));
+                        id,
+                        entry.Key,
+                        text,
+                        filePath: FilePathFor(project, entry.Key)
+                    );
                 }
             }
 
             return solution;
         }
 
-        private static async Task<string?> ResolveKeyAsync(Solution solution, Diagnostic diagnostic, CancellationToken ct)
+        private static async Task<string?> ResolveKeyAsync(
+            Solution solution,
+            Diagnostic diagnostic,
+            CancellationToken ct
+        )
         {
-            if (diagnostic.Location.SourceTree is not { } tree
-                || solution.GetDocument(tree) is not { } document)
+            if (
+                diagnostic.Location.SourceTree is not { } tree
+                || solution.GetDocument(tree) is not { } document
+            )
             {
                 return null;
             }

--- a/src/CsSig/CodeFixes/StaticCs.CsSig.CodeFixes.csproj
+++ b/src/CsSig/CodeFixes/StaticCs.CsSig.CodeFixes.csproj
@@ -14,7 +14,7 @@
   -->
   <PropertyGroup>
     <PackageId>StaticCS.CsSig</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>agocke</Authors>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/CsSig/CodeFixes/StaticCs.CsSig.CodeFixes.csproj
+++ b/src/CsSig/CodeFixes/StaticCs.CsSig.CodeFixes.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -29,7 +28,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference
+      Include="Microsoft.CodeAnalysis.CSharp.Workspaces"
+      Version="5.0.0"
+      PrivateAssets="all"
+    />
     <ProjectReference Include="../Analyzer/StaticCs.CsSig.Analyzers.csproj" PrivateAssets="all" />
   </ItemGroup>
 
@@ -39,10 +42,23 @@
     separate assembly. The host (the IDE / compiler) supplies the Microsoft.CodeAnalysis.* assemblies.
   -->
   <ItemGroup>
-    <None Include="$(OutputPath)/StaticCs.CsSig.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="$(OutputPath)/StaticCs.CsSig.CodeFixes.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="../Analyzer/build/StaticCS.CsSig.props" Pack="true" PackagePath="build/StaticCS.CsSig.props" />
+    <None
+      Include="$(OutputPath)/StaticCs.CsSig.Analyzers.dll"
+      Pack="true"
+      PackagePath="analyzers/dotnet/cs"
+      Visible="false"
+    />
+    <None
+      Include="$(OutputPath)/StaticCs.CsSig.CodeFixes.dll"
+      Pack="true"
+      PackagePath="analyzers/dotnet/cs"
+      Visible="false"
+    />
+    <None
+      Include="../Analyzer/build/StaticCS.CsSig.props"
+      Pack="true"
+      PackagePath="build/StaticCS.CsSig.props"
+    />
     <None Include="../Analyzer/README.md" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
-
 </Project>

--- a/src/CsSig/CodeFixes/StaticCs.CsSig.CodeFixes.csproj
+++ b/src/CsSig/CodeFixes/StaticCs.CsSig.CodeFixes.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" PrivateAssets="all" />
     <ProjectReference Include="../Analyzer/StaticCs.CsSig.Analyzers.csproj" PrivateAssets="all" />
   </ItemGroup>
 

--- a/test/test/ClosedTests.cs
+++ b/test/test/ClosedTests.cs
@@ -4,10 +4,9 @@ using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
 using Xunit;
 
 namespace StaticCs.Tests;
@@ -343,11 +342,11 @@ class C
 
     private static readonly DiagnosticResult ClosedEnumConversion = CSharpAnalyzerVerifier<
         EnumClosedConversionAnalyzer,
-        XUnitVerifier
+        DefaultVerifier
     >.Diagnostic(DiagId.ClosedEnumConversion.ToIdString());
     private static readonly DiagnosticResult ClassOrRecordMustBeClosed = CSharpAnalyzerVerifier<
         ClosedDeclarationChecker,
-        XUnitVerifier
+        DefaultVerifier
     >.Diagnostic(DiagId.ClassOrRecordMustBeClosed.ToIdString());
 
     private Task VerifyDiagnostics<TAnalyzer>(string src, params DiagnosticResult[] expected)

--- a/test/test/CsSigTests.cs
+++ b/test/test/CsSigTests.cs
@@ -577,6 +577,95 @@ public class CsSigTests
     }
 
     [Fact]
+    public async Task RoundTripExtensionMembers()
+    {
+        // C# 14 extension blocks: each `extension(Receiver) { ... }` is modelled by Roslyn as a
+        // nested type with an unspeakable name. The writer must emit it as an `extension(...)` block
+        // (not a nameless `class`), and the round-trip must produce no diagnostics.
+        await AssertRoundTripsAsync("""
+            namespace N
+            {
+                public static class Ext
+                {
+                    extension(int[])
+                    {
+                        public static string Describe => "ints";
+                    }
+                    extension<T>(T[] source)
+                    {
+                        public int Count2 => source.Length;
+                        public bool TryFirst(out T value) { value = default!; return false; }
+                        public static T[] Empty => System.Array.Empty<T>();
+                    }
+                }
+            }
+            """, nullable: true, languageVersion: LanguageVersion.Preview);
+    }
+
+    [Fact]
+    public async Task ExtensionMemberMissingFromProjectReported()
+    {
+        var source = """
+            namespace N;
+            public static class Ext
+            {
+                extension<T>(T[] source)
+                {
+                    public int Count2 => source.Length;
+                }
+            }
+            """;
+        var sig = """
+            namespace N
+            {
+                public static class Ext
+                {
+                    extension<T>(T[] source)
+                    {
+                        public int Count2 { get; }
+                        public static int Bogus { get; }
+                    }
+                }
+            }
+            """;
+        // `Bogus` is declared in the signature but absent from the project: exactly one report.
+        var diagnostic = Assert.Single(await RunPreviewAsync(source, sig));
+        Assert.Equal("CSSIG001", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task ExtensionMemberMissingFromSignatureReported()
+    {
+        var source = """
+            namespace N;
+            public static class Ext
+            {
+                extension<T>(T[] source)
+                {
+                    public int Count2 => source.Length;
+                    public static T[] Empty => System.Array.Empty<T>();
+                }
+            }
+            """;
+        var sig = """
+            namespace N
+            {
+                public static class Ext
+                {
+                    extension<T>(T[] source)
+                    {
+                        public int Count2 { get; }
+                    }
+                }
+            }
+            """;
+        // `Empty` exists in the project but is not declared: exactly one report (no double-count
+        // from the implicit implementation method the compiler synthesises on the static class).
+        var diagnostic = Assert.Single(await RunPreviewAsync(source, sig));
+        Assert.Equal("CSSIG002", diagnostic.Id);
+    }
+
+    [Fact]
     public async Task RoundTripFunctionPointerAndVolatile()
     {
         await AssertRoundTripsAsync("""
@@ -593,7 +682,8 @@ public class CsSigTests
 
     /// <summary>Generates a <c>.cssig</c> from <paramref name="source"/> and asserts that feeding it
     /// back through the analyzer reports no diagnostics.</summary>
-    private static async Task AssertRoundTripsAsync(string source, bool nullable = false)
+    private static async Task AssertRoundTripsAsync(
+        string source, bool nullable = false, LanguageVersion languageVersion = LanguageVersion.Default)
     {
         var references = await ReferenceAssemblies.Net.Net60.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
         var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true);
@@ -604,14 +694,12 @@ public class CsSigTests
 
         var compilation = CSharpCompilation.Create(
             "TestProject",
-            new[] { CSharpSyntaxTree.ParseText(source, path: "Test.cs") },
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(languageVersion), path: "Test.cs") },
             references,
             compilationOptions);
 
         var generated = CsSigWriter.Write(compilation);
-        var diagnostics = nullable
-            ? await RunNullableAsync(source, generated)
-            : await RunAsync(source, generated);
+        var diagnostics = await RunCoreAsync(source, equivalence: null, nullable, languageVersion, generated);
         Assert.Empty(diagnostics);
     }
 
@@ -1082,24 +1170,28 @@ public class CsSigTests
     }
 
     private static Task<ImmutableArray<Diagnostic>> RunAsync(string source, params string[] signatureFiles)
-        => RunCoreAsync(source, equivalence: null, nullable: false, signatureFiles);
+        => RunCoreAsync(source, equivalence: null, nullable: false, LanguageVersion.Default, signatureFiles);
+
+    private static Task<ImmutableArray<Diagnostic>> RunPreviewAsync(string source, params string[] signatureFiles)
+        => RunCoreAsync(source, equivalence: null, nullable: true, LanguageVersion.Preview, signatureFiles);
 
     private static Task<ImmutableArray<Diagnostic>> RunNullableAsync(string source, params string[] signatureFiles)
-        => RunCoreAsync(source, equivalence: null, nullable: true, signatureFiles);
+        => RunCoreAsync(source, equivalence: null, nullable: true, LanguageVersion.Default, signatureFiles);
 
     private static Task<ImmutableArray<Diagnostic>> RunWithEquivalenceAsync(
         string source, string? equivalence, params string[] signatureFiles)
-        => RunCoreAsync(source, equivalence, nullable: false, signatureFiles);
+        => RunCoreAsync(source, equivalence, nullable: false, LanguageVersion.Default, signatureFiles);
 
     private static Task<ImmutableArray<Diagnostic>> RunNullableWithEquivalenceAsync(
         string source, string? equivalence, params string[] signatureFiles)
-        => RunCoreAsync(source, equivalence, nullable: true, signatureFiles);
+        => RunCoreAsync(source, equivalence, nullable: true, LanguageVersion.Default, signatureFiles);
 
     private static async Task<ImmutableArray<Diagnostic>> RunCoreAsync(
-        string source, string? equivalence, bool nullable, params string[] signatureFiles)
+        string source, string? equivalence, bool nullable, LanguageVersion languageVersion, params string[] signatureFiles)
     {
         var references = await ReferenceAssemblies.Net.Net60.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
 
+        var parseOptions = new CSharpParseOptions(languageVersion);
         var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true);
         if (nullable)
         {
@@ -1108,7 +1200,7 @@ public class CsSigTests
 
         var compilation = CSharpCompilation.Create(
             "TestProject",
-            new[] { CSharpSyntaxTree.ParseText(source, path: "Test.cs") },
+            new[] { CSharpSyntaxTree.ParseText(source, parseOptions, path: "Test.cs") },
             references,
             compilationOptions);
 

--- a/test/test/SuppressorTest.cs
+++ b/test/test/SuppressorTest.cs
@@ -5,11 +5,10 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace StaticCs.Tests;
 
-internal class SuppressorTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier>
+internal class SuppressorTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, DefaultVerifier>
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
     public CSharpCompilationOptions CompilationOptions { get; private init; } =

--- a/test/test/test.csproj
+++ b/test/test/test.csproj
@@ -11,8 +11,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.4" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/test/test/test.csproj
+++ b/test/test/test.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />


### PR DESCRIPTION
## Summary

Projects using **C# 14 extension members** (`extension(Receiver) { ... }`) produced broken `.cssig` files: each block was emitted as a nameless `public class { ... }`. Roslyn models each block as a nested type with an unspeakable, compiler-generated name, which the writer rendered as an empty class name.

## Changes

- **`ExtensionMembers` helper** — recognises extension marker types and their receivers via `INamedTypeSymbol.IsExtension` / `ExtensionParameter` / `TypeKind.Extension`.
- **Writer** — emits proper `extension<T>(receiver) { ... }` blocks (deterministically ordered), rendering the receiver with ref-kind and nullability.
- **Signature model** — keys extension markers by a fixed `<extension>` discriminator plus the receiver type, so distinct blocks sharing a receiver are not conflated (soundness).
- **API surface** — no longer double-counts the implicit implementation methods the compiler synthesises on the host static class; members are tracked through the extension marker types.
- **Roslyn 5.0** — bump the analyzer/code-fix projects from the `Microsoft.CodeAnalysis` 4.0 baseline to 5.0 (extension members require it), removing the previous reflection/numeric-enum workarounds and the now-stale `(RefKind)4` fallback. RS1035/RS1037 (newly enforced) are suppressed via a documented global config.
- **Tests** — bump the harness to Roslyn 5.x (`Microsoft.CodeAnalysis.Analyzer.Testing` 1.1.4, `CSharp.Workspaces` 5.3.0) and add round-trip + soundness regression tests.

## Validation

- Round-trip (generate → analyze) on extension members: **0 diagnostics**.
- Missing / extra extension members each report exactly one `CSSIG001`/`CSSIG002`.
- Regenerated a real-world `PublicAPI.cssig` (serde): all `extension(...)` blocks correct, no nameless classes, nullable receivers preserved.
- Full suite: **94 passed**, 1 skipped.
