### PR TITLE
Retarget CsSig analyzer + fixer to netstandard2.0

### DIFF
--- a/src/CsSig/Analyzer/CsSigRecognizer.cs
+++ b/src/CsSig/Analyzer/CsSigRecognizer.cs
@@ -81,26 +81,26 @@ internal static class CsSigRecognizer
         /// Modifiers allowed on a virtualizable member (method, property, indexer, event): the
         /// comparison captures all of these as part of the member's virtuality.
         /// </summary>
-        private static readonly SyntaxKind[] s_memberModifiers =
-        {
+        private static ReadOnlySpan<SyntaxKind> MemberModifiers =>
+        [
             SyntaxKind.StaticKeyword,
             SyntaxKind.VirtualKeyword,
             SyntaxKind.AbstractKeyword,
             SyntaxKind.OverrideKeyword,
             SyntaxKind.SealedKeyword,
-        };
+        ];
 
         // Members that can be 'readonly' on a struct (the modifier makes the member readonly,
         // turning `this` into an `in` parameter — observable in both source and binary).
-        private static readonly SyntaxKind[] s_readonlyMemberModifiers =
-        {
+        private static ReadOnlySpan<SyntaxKind> ReadonlyMemberModifiers =>
+        [
             SyntaxKind.StaticKeyword,
             SyntaxKind.VirtualKeyword,
             SyntaxKind.AbstractKeyword,
             SyntaxKind.OverrideKeyword,
             SyntaxKind.SealedKeyword,
             SyntaxKind.ReadOnlyKeyword,
-        };
+        ];
 
         /// <summary>
         /// Rejects every modifier that is not accessibility (always allowed, since it determines
@@ -234,7 +234,7 @@ internal static class CsSigRecognizer
         {
             // 'readonly' is allowed: on a struct instance method it marks the method readonly,
             // making `this` an `in` parameter (observable in both source and binary).
-            CheckModifiers(node.Modifiers, s_readonlyMemberModifiers);
+            CheckModifiers(node.Modifiers, ReadonlyMemberModifiers);
             RejectBody(node.Body, node.ExpressionBody);
             base.VisitMethodDeclaration(node);
         }
@@ -271,27 +271,27 @@ internal static class CsSigRecognizer
 
         public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
         {
-            CheckModifiers(node.Modifiers, s_readonlyMemberModifiers);
+            CheckModifiers(node.Modifiers, ReadonlyMemberModifiers);
             RejectBody(body: null, node.ExpressionBody);
             base.VisitPropertyDeclaration(node);
         }
 
         public override void VisitIndexerDeclaration(IndexerDeclarationSyntax node)
         {
-            CheckModifiers(node.Modifiers, s_readonlyMemberModifiers);
+            CheckModifiers(node.Modifiers, ReadonlyMemberModifiers);
             RejectBody(body: null, node.ExpressionBody);
             base.VisitIndexerDeclaration(node);
         }
 
         public override void VisitEventDeclaration(EventDeclarationSyntax node)
         {
-            CheckModifiers(node.Modifiers, s_memberModifiers);
+            CheckModifiers(node.Modifiers, MemberModifiers);
             base.VisitEventDeclaration(node);
         }
 
         public override void VisitEventFieldDeclaration(EventFieldDeclarationSyntax node)
         {
-            CheckModifiers(node.Modifiers, s_memberModifiers);
+            CheckModifiers(node.Modifiers, MemberModifiers);
             base.VisitEventFieldDeclaration(node);
         }
 

--- a/src/CsSig/Analyzer/CsSigRecognizer.cs
+++ b/src/CsSig/Analyzer/CsSigRecognizer.cs
@@ -133,7 +133,16 @@ internal static class CsSigRecognizer
                     continue;
                 }
 
-                if (allowed.IndexOf(kind) >= 0)
+                var isAllowed = false;
+                foreach (var allowedKind in allowed)
+                {
+                    if (allowedKind == kind)
+                    {
+                        isAllowed = true;
+                        break;
+                    }
+                }
+                if (isAllowed)
                 {
                     continue;
                 }

--- a/src/CsSig/Analyzer/IsExternalInit.cs
+++ b/src/CsSig/Analyzer/IsExternalInit.cs
@@ -1,0 +1,5 @@
+// Polyfill required for init-only setters and records when targeting netstandard2.0.
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}

--- a/src/CsSig/Analyzer/StaticCs.CsSig.Analyzers.csproj
+++ b/src/CsSig/Analyzer/StaticCs.CsSig.Analyzers.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
     <AssemblyName>StaticCs.CsSig.Analyzers</AssemblyName>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 

--- a/src/CsSig/CodeFixes/StaticCs.CsSig.CodeFixes.csproj
+++ b/src/CsSig/CodeFixes/StaticCs.CsSig.CodeFixes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AssemblyName>StaticCs.CsSig.CodeFixes</AssemblyName>
@@ -14,7 +14,7 @@
   -->
   <PropertyGroup>
     <PackageId>StaticCS.CsSig</PackageId>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Authors>agocke</Authors>
     <IsPackable>true</IsPackable>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>


### PR DESCRIPTION
The `net10.0` analyzer build wasn't loading in VS Code. This moves both the analyzer and code-fix projects back to `netstandard2.0`.

## Changes
- Retarget `StaticCs.CsSig.Analyzers` and `StaticCs.CsSig.CodeFixes` to `netstandard2.0`.
- Add `LangVersion=latest` + an `IsExternalInit` polyfill so records/`init` setters compile on netstandard2.0.
- Replace `ReadOnlySpan<SyntaxKind>.IndexOf` (requires `IEquatable<T>` on netstandard2.0) with a manual loop.
- Bump package version to 0.3.1.

## Validation
- `dotnet test test/test/test.csproj` — 111 passed, 1 skipped.
