### PR TITLE
Collapse malformed .cssig diagnostic cascade

### DIFF
--- a/src/CsSig/Analyzer/ApiSurface.cs
+++ b/src/CsSig/Analyzer/ApiSurface.cs
@@ -67,7 +67,10 @@ internal static class ApiSurface
     /// Collects the tracked entries contributed by a single type (the type itself and its members),
     /// so per-symbol analysis can diff one type at a time against the declared surface.
     /// </summary>
-    public static Dictionary<MemberIdentity, ApiEntry> CollectType(INamedTypeSymbol type, bool isDeclaration)
+    public static Dictionary<MemberIdentity, ApiEntry> CollectType(
+        INamedTypeSymbol type,
+        bool isDeclaration
+    )
     {
         var map = new Dictionary<MemberIdentity, ApiEntry>();
         CollectInto(type, map, isDeclaration);

--- a/src/CsSig/Analyzer/CsSigAnalyzer.cs
+++ b/src/CsSig/Analyzer/CsSigAnalyzer.cs
@@ -112,19 +112,23 @@ public sealed class CsSigAnalyzer : DiagnosticAnalyzer
                 cancellationToken: context.CancellationToken
             );
 
-            foreach (var diagnostic in tree.GetDiagnostics(context.CancellationToken))
+            // A single malformed signature file cascades into dozens of follow-on errors (a
+            // construct that needs a newer language version, for example, yields a parse error per
+            // member). Report only the first parse error per file and skip the grammar recognizer:
+            // the file can't be diffed, so the extra noise is unactionable.
+            var firstError = tree.GetDiagnostics(context.CancellationToken)
+                .FirstOrDefault(static d => d.Severity == DiagnosticSeverity.Error);
+            if (firstError is not null)
             {
-                if (diagnostic.Severity == DiagnosticSeverity.Error)
-                {
-                    hadParseError = true;
-                    fileDiagnostics.Add(
-                        Diagnostic.Create(
-                            s_signatureFileError,
-                            CsSigLocation.ToExternal(diagnostic.Location, file.Path),
-                            diagnostic.GetMessage()
-                        )
-                    );
-                }
+                hadParseError = true;
+                fileDiagnostics.Add(
+                    Diagnostic.Create(
+                        s_signatureFileError,
+                        CsSigLocation.ToExternal(firstError.Location, file.Path),
+                        firstError.GetMessage()
+                    )
+                );
+                continue;
             }
 
             // Recognize the .cssig grammar: reject any construct outside the signature sublanguage

--- a/test/test/CsSigTests.cs
+++ b/test/test/CsSigTests.cs
@@ -273,6 +273,28 @@ public class CsSigTests
     }
 
     [Fact]
+    public async Task MalformedSignatureFileReportsSingleParseErrorWithoutGrammarNoise()
+    {
+        // A wrong-target signature file (constructs that don't parse here) used to cascade into
+        // many CSSIG003/CSSIG004 errors. Collapse to a single parse error and suppress the grammar
+        // recognizer for that file, since it can't be diffed.
+        var source = """
+            namespace N;
+            public class C() { }
+            """;
+        var sig = """
+            namespace N;
+            public class C() {
+            public int A() { }
+            public int B() { }
+            public int D() { }
+            """;
+        var diagnostics = await RunAsync(source, sig);
+        Assert.Equal(1, diagnostics.Count(d => d.Id == "CSSIG003"));
+        Assert.DoesNotContain(diagnostics, d => d.Id == "CSSIG004");
+    }
+
+    [Fact]
     public async Task PartialInSignatureFileReported()
     {
         var source = """


### PR DESCRIPTION
A wrong-target or otherwise unparseable `.cssig` produced a flood of `CSSIG003`/`CSSIG004` errors — one per member (serde saw ~180 on its net8 leg). This collapses the noise.

## Change
- Report only the **first** parse error per file, and skip the grammar recognizer for a file that doesn't parse (it can't be diffed, so the extra diagnostics are unactionable).
- Adds a test asserting one CSSIG003 and zero CSSIG004 for a malformed file.
- Formats ApiSurface.cs (predated the CSharpier gate).

## Validation
- `dotnet test test/test/test.csproj` — 112 passed, 1 skipped.
- `dotnet csharpier check .` clean.
