### PR TITLE
cssig: distinguish abstract vs default-implemented interface members

### DIFF
--- a/src/CsSig/Analyzer/CsSigWriter.cs
+++ b/src/CsSig/Analyzer/CsSigWriter.cs
@@ -289,16 +289,46 @@ public static class CsSigWriter
             .Replace("volatile ", string.Empty)
             .Replace("required ", string.Empty);
 
-        // Roslyn's SymbolDisplay suppresses every modifier (including `static`) on interface
-        // members, treating them all as implicit. `static` is observable and representable, so put
-        // it back; the remaining virtuality modifiers are intentionally not tracked for interface
-        // members (a body-less signature cannot express default implementations — see FlagsFrom).
-        if (
-            member is { IsStatic: true, ContainingType.TypeKind: TypeKind.Interface }
-            && !text.StartsWith("static ", StringComparison.Ordinal)
-        )
+        // Roslyn's SymbolDisplay suppresses every modifier on interface members, treating them all
+        // as implicit. The observable ones (`static`, and the virtuality bits that distinguish an
+        // abstract member from a default-implemented one — see FlagsFrom) are representable, so put
+        // them back. `abstract` is the implicit default and is left off; a default implementation
+        // surfaces as `virtual`. A body-less `virtual` member is a semantic error in plain C# but
+        // parses fine, exactly like a body-less `int M();`.
+        if (member is { ContainingType.TypeKind: TypeKind.Interface })
         {
-            text = "static " + text;
+            var modifiers = new List<string>();
+            if (member.IsStatic)
+            {
+                modifiers.Add("static");
+            }
+
+            // Instance interface members are implicitly abstract, but static ones are not, so the
+            // `abstract` keyword must be written for a static abstract member to round-trip.
+            if (member.IsStatic && member.IsAbstract)
+            {
+                modifiers.Add("abstract");
+            }
+
+            if (member.IsVirtual)
+            {
+                modifiers.Add("virtual");
+            }
+
+            if (member.IsSealed)
+            {
+                modifiers.Add("sealed");
+            }
+
+            if (member.IsOverride)
+            {
+                modifiers.Add("override");
+            }
+
+            if (modifiers.Count > 0)
+            {
+                text = string.Join(" ", modifiers) + " " + text;
+            }
         }
 
         // ShowReadWriteDescriptor already renders the `{ get; set; }` body for properties/indexers,

--- a/src/CsSig/Analyzer/GRAMMAR.md
+++ b/src/CsSig/Analyzer/GRAMMAR.md
@@ -61,8 +61,11 @@ protected` are rejected (`CSSIG004`) — they cannot appear on any member, acces
 | enum member                                | (none)                           | n/a              | an explicit `= value` is allowed and is part of the signature   |
 
 `virtual` / `abstract` / `override` / `sealed` on a member are captured as its *virtuality* and
-affect both equivalences (see below). Interface members are implicitly `abstract`, so the modifier
-need not be written there.
+affect both equivalences (see below). An instance interface member is implicitly `abstract`, so that
+modifier need not be written there; a member with a default implementation is `virtual` and must be
+written `virtual` to distinguish it (removing a default implementation re-breaks every implementer).
+A `static abstract` interface member must spell out `abstract`, since `static` members are not
+implicitly abstract.
 
 ### No bodies
 

--- a/src/CsSig/Analyzer/SignatureModel.cs
+++ b/src/CsSig/Analyzer/SignatureModel.cs
@@ -491,24 +491,10 @@ internal sealed record ApiMember(MemberIdentity Identity, SourceMember Source, B
             | (symbol.IsOverride ? MemberFlags.Override : MemberFlags.None)
             | (symbol.IsSealed ? MemberFlags.Sealed : MemberFlags.None);
 
-        // A body-less .cssig cannot tell an abstract interface member apart from a default-
-        // implemented (virtual) one: the body is the only difference, and signatures carry no
-        // bodies. The same applies to `static abstract` vs `static virtual` members. So the
-        // virtuality of an interface's own members is unobservable through this format — normalize
-        // it away (keeping static-ness) so the written form and the original symbol compare equal.
-        if (
-            symbol is
-            { Kind: not SymbolKind.NamedType, ContainingType.TypeKind: TypeKind.Interface }
-        )
-        {
-            flags &= ~(
-                MemberFlags.Virtual
-                | MemberFlags.Abstract
-                | MemberFlags.Override
-                | MemberFlags.Sealed
-            );
-        }
-
+        // An interface's own members carry their virtuality: an abstract member (no default
+        // implementation) and a virtual one (with a default implementation) are different breaking-
+        // change shapes — removing a default implementation re-breaks every implementer. The writer
+        // emits a default implementation as `virtual`, so the distinction survives the round trip.
         return flags;
     }
 

--- a/test/test/CsSigTests.cs
+++ b/test/test/CsSigTests.cs
@@ -766,9 +766,10 @@ public class CsSigTests
     [Fact]
     public async Task RoundTripDefaultInterfaceMethods()
     {
-        // A default interface method (one with a body) is `virtual`, whereas the body-less form
-        // written to a .cssig is `abstract`. The two must compare equal: a signature file cannot
-        // carry a body, so it cannot distinguish the two.
+        // A default interface method (one with a body) is `virtual`; an abstract member is body-
+        // less. The .cssig cannot carry a body, so the writer emits a default implementation as
+        // `virtual` to preserve the distinction. Round-tripping must keep abstract and virtual
+        // members distinct rather than collapsing them.
         await AssertRoundTripsAsync(
             """
             namespace N
@@ -1163,8 +1164,8 @@ public class CsSigTests
     [Fact]
     public async Task InterfaceMemberStaticnessStillReported()
     {
-        // FlagsFrom normalizes virtuality away for interface members but keeps static-ness, so a
-        // static-vs-instance mismatch must still be reported.
+        // Interface members carry their virtuality (abstract vs default-implemented), but a
+        // static-vs-instance mismatch is still reported on top of that.
         var source = """
             namespace N;
             public interface IThing
@@ -1177,6 +1178,29 @@ public class CsSigTests
             public interface IThing
             {
                 int M();
+            }
+            """;
+        var diagnostic = Assert.Single(await RunPreviewAsync(source, sig));
+        Assert.Equal("CSSIG005", diagnostic.Id);
+    }
+
+    [Fact]
+    public async Task InterfaceDefaultImplementationRemovalReported()
+    {
+        // Removing a default implementation (virtual -> abstract) re-breaks every implementer, so a
+        // .cssig that still promises the default must mismatch the now-abstract source member.
+        var source = """
+            namespace N;
+            public interface IThing
+            {
+                int M();
+            }
+            """;
+        var sig = """
+            namespace N;
+            public interface IThing
+            {
+                virtual int M();
             }
             """;
         var diagnostic = Assert.Single(await RunPreviewAsync(source, sig));


### PR DESCRIPTION
## Problem
cssig normalized away virtuality for all interface members, so an **abstract** method and one with a **default implementation** were indistinguishable. Removing a default implementation — which re-breaks every implementer — went undetected, contrary to breaking-change requirements.

## Changes
- **`SignatureModel.cs`** — `FlagsFrom` no longer strips virtuality bits for interface members; abstract vs. default-implemented (`virtual`) is now part of the compared signature.
- **`CsSigWriter.cs`** — emits `virtual` for default-implemented interface members and explicit `abstract` for `static abstract` members (static members aren't implicitly abstract) so signatures round-trip while preserving the distinction. Instance abstract members stay implicit.
- **`GRAMMAR.md`** — documents the modifier rules.
- **Tests** — added `InterfaceDefaultImplementationRemovalReported` (virtual→abstract flagged CSSIG005); updated `RoundTripDefaultInterfaceMethods` and the static-ness test. All 63 CsSig tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>